### PR TITLE
Langsmith tracing

### DIFF
--- a/src/history_book/llm/config.py
+++ b/src/history_book/llm/config.py
@@ -30,7 +30,7 @@ class LLMConfig:
         "using the provided context from historical documents. Always base your "
         "answers on the context provided and cite specific information when possible."
     )
-    max_context_length: int = 4000  # Max characters for context
+    max_context_length: int = 100000  # Max characters for context
     max_conversation_length: int = 20  # Max messages to include in history
 
     # Provider-specific settings

--- a/src/history_book/llm/utils.py
+++ b/src/history_book/llm/utils.py
@@ -41,7 +41,7 @@ def format_messages_for_llm(
     return formatted_messages
 
 
-def format_context_for_llm(context: str | None, max_length: int = 4000) -> str | None:
+def format_context_for_llm(context: str | None, max_length: int | None = None) -> str | None:
     """
     Format context text for LLM consumption.
 
@@ -56,7 +56,7 @@ def format_context_for_llm(context: str | None, max_length: int = 4000) -> str |
         return None
 
     # Truncate if too long
-    if len(context) > max_length:
+    if max_length and len(context) > max_length:
         # Try to truncate at sentence boundaries
         truncated = context[:max_length]
         last_period = truncated.rfind(".")

--- a/src/history_book/llm/utils.py
+++ b/src/history_book/llm/utils.py
@@ -41,7 +41,9 @@ def format_messages_for_llm(
     return formatted_messages
 
 
-def format_context_for_llm(context: str | None, max_length: int | None = None) -> str | None:
+def format_context_for_llm(
+    context: str | None, max_length: int | None = None
+) -> str | None:
     """
     Format context text for LLM consumption.
 

--- a/src/history_book/services/chat_service.py
+++ b/src/history_book/services/chat_service.py
@@ -3,6 +3,7 @@
 import logging
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
+
 from langsmith import traceable
 
 from history_book.data_models.entities import (

--- a/src/history_book/services/chat_service.py
+++ b/src/history_book/services/chat_service.py
@@ -3,6 +3,7 @@
 import logging
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
+from langsmith import traceable
 
 from history_book.data_models.entities import (
     ChatMessage,
@@ -137,6 +138,7 @@ class ChatService:
             logger.error(f"Failed to get messages for session {session_id}: {e}")
             return []
 
+    @traceable
     async def send_message(
         self,
         session_id: str,


### PR DESCRIPTION
This pull request introduces several improvements to context handling and observability in the LLM chat service. The most significant changes include increasing the maximum context length for LLM input, making context truncation more flexible, and adding tracing for the message sending workflow.

**Context handling improvements:**

* Increased `max_context_length` in `LLMConfig` from 4,000 to 100,000 characters -- previous limit was truncating after only a few paragraphs.
* Updated `format_context_for_llm` to accept an optional `max_length` parameter instead of a fixed default, providing more flexibility for context truncation.
* Improved truncation logic in `format_context_for_llm` to only apply truncation when `max_length` is set, preventing unintended behavior when no limit is specified.

**Observability and tracing:**

* Added import of `traceable` from `langsmith` to enable tracing of service methods.
* Decorated the `send_message` method in `ChatService` with `@traceable`, enabling better tracking and debugging of message flows.