### PR TITLE
Knowledge graph metrics

### DIFF
--- a/docs/plans/kg_explorer_spec_add_metrics.md
+++ b/docs/plans/kg_explorer_spec_add_metrics.md
@@ -1,0 +1,562 @@
+# Knowledge Graph Explorer — Frontend Architecture Spec
+
+> **Handoff note for Claude Code:** This document captures architecture decisions and requirements agreed upon during planning. Implementation details (exact component file structure, hook implementations, MUI component choices, Redux toolkit boilerplate, etc.) are intentionally left to you. The goal is to preserve the *why* behind each decision so you can implement confidently without needing to re-litigate choices. Where a decision is flagged as "deferred," that means it was explicitly not decided during planning and is yours to make.
+
+---
+
+## 1. Project context
+
+- **Backend:** Python / FastAPI, knowledge graph stored in Weaviate
+- **Frontend:** React, MUI component library, Redux for state management
+- **New addition:** A single standalone page — the Knowledge Graph Explorer — added alongside existing pages in the project
+- **Graph library:** `react-force-graph-2d` (already selected; Cytoscape.js is the fallback if issues arise)
+
+The knowledge graph is hierarchical: separate pre-built graphs exist for each chapter, each book, and the full volume. The frontend does not filter a single graph — it loads a different graph object depending on scope selection.
+
+---
+
+## 2. Page layout
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                           Top bar                                │
+│  [Search________] [Book▾] [Chapter▾] [Size▾] [Color▾] [Controls]│
+├──────────────────────────────────┬───────────────────────────────┤
+│                                  │                               │
+│          Graph panel             │       Entity panel            │
+│       (react-force-graph)        │   (detail / stats / metrics)  │
+│                                  │                               │
+│                                  │                               │
+└──────────────────────────────────┴───────────────────────────────┘
+```
+
+- Graph panel and entity panel are **side by side with a draggable resize handle**
+- No mobile/responsive requirement at this stage
+- The top bar contains: search, scope selectors (book + chapter), node size metric selector, node color metric selector, N-hop toggle, hop count selector, and back/forward history buttons
+
+---
+
+## 3. State management
+
+**Redux** handles all UI state. **TanStack Query** handles all server state (fetching, caching, refetching). They are complementary: Redux owns what the user has *chosen*, TanStack Query owns what the server has *returned*.
+
+### Redux slice: `graphSlice`
+
+| Field | Type | Notes |
+|---|---|---|
+| `focusEntityId` | `string \| null` | `null` = no focus |
+| `scope` | `Scope` | See DTO section |
+| `displayMode` | `'full' \| 'nhop'` | Full graph vs N-hop subgraph |
+| `hopCount` | `1 \| 2 \| 3` | Default: **2** |
+| `focusHistory` | `string[]` | Array of entity UUIDs, for back/forward |
+| `historyIndex` | `number` | Current position in focusHistory |
+| `searchResults` | `SearchResult[]` | Populated on search submit, cleared on new search |
+| `colorMap` | `Record<EntityType, string>` | Entity type → hex color, derived once from graph load |
+
+### Redux slice: `metricsSlice`
+
+| Field | Type | Notes |
+|---|---|---|
+| `nodeSizeMetric` | `NodeSizeMetric` | Currently selected size metric; default `'occurrence_count'` |
+| `nodeColorMetric` | `NodeColorMetric \| NodePairMetric` | Currently selected color metric; default `'entity_type'` |
+| `nodeSizeParams` | `Record<string, number>` | Parameter overrides for current size metric (e.g. `{ damping: 0.85 }`) |
+| `nodeColorParams` | `Record<string, number>` | Parameter overrides for current color metric (e.g. `{ k: 4 }`) |
+
+Metric name values are string enums defined to match backend metric identifiers exactly (see §10).
+
+### TanStack Query hooks (keyed off Redux state)
+
+| Hook | Query key | Fires when |
+|---|---|---|
+| `useGraphQuery(scope)` | `['graph', scope]` | Scope changes |
+| `useSubgraphQuery(entityId, hops, scope)` | `['subgraph', entityId, hops, scope]` | `focusEntityId` changes + `displayMode === 'nhop'` |
+| `useEntityQuery(entityId)` | `['entity', entityId]` | `focusEntityId` changes (non-null) |
+| `useSearchQuery(query, filters, scope)` | n/a — triggered manually | User submits search (enter key) |
+| `useBooksQuery()` | `['books']` | Once on page mount |
+| `useGraphMetricsQuery(scope)` | `['metrics', 'graph', scope]` | Scope changes |
+| `useNodeMetricQuery(scope, metric, params)` | `['metrics', 'node', scope, metric, params]` | Size or color metric selection changes |
+| `useNodePairMetricQuery(scope, focusId, metric, params)` | `['metrics', 'node-pair', scope, focusId, metric, params]` | Focus changes + node-pair color metric selected |
+
+`useSearchQuery` is triggered imperatively (on enter), not reactively, so search results live in Redux rather than TanStack Query cache.
+
+`useNodeMetricQuery` and `useGraphMetricsQuery` use `refetchInterval` polling when the response status is `202 Accepted` (metric still computing on backend). Polling stops when a `200` with data is received.
+
+---
+
+## 4. Focus entity behavior
+
+"Focus" is the central interaction concept. It means: *this entity is selected, the entity panel shows its details, and if N-hop mode is on, the graph shows its subgraph.*
+
+### Setting focus
+Focus can be set from three places:
+1. **Click a node** in the graph panel → `dispatch(setFocus(entityId))`
+2. **Click a relationship** in the entity panel → `dispatch(setFocus(otherEntityId))` — this is a *full focus*: updates graph + entity panel + re-centers graph view
+3. **Select a search result** → `dispatch(setFocus(entityId))` + `dispatch(setDisplayMode('nhop'))`
+
+### Clearing focus
+- Click the canvas background (graph panel)
+- Click the "unfocus" button in the entity panel (only visible when focused)
+
+**Clearing focus always resets to full-graph mode.** N-hop mode without a focus entity is meaningless, so `clearFocus()` should set `displayMode` back to `'full'` as part of the same action.
+
+**Clearing focus silently deactivates node-pair color metrics.** If a node-pair metric (e.g. cosine similarity) is active when focus is cleared, the graph falls back to the entity_type default coloring. The `metricsSlice` selection is preserved — it reactivates automatically when a new focus is set.
+
+### Focus + re-center
+When focus is set (from any source), the graph panel must call `graphRef.current.centerAt(node.x, node.y, durationMs)` reactively. Implement this as a `useEffect` watching `focusEntityId` that reads the current node position from the simulation and calls `centerAt`.
+
+### Focus history
+`focusHistory` tracks entity UUIDs only (not scope changes). Back/forward buttons step through `historyIndex`. When a new focus is set mid-history (i.e. `historyIndex < focusHistory.length - 1`), truncate forward history — standard browser-history semantics. This feature is **lower priority** and can be scaffolded without full implementation initially.
+
+---
+
+## 5. Scope change behavior
+
+On scope change (book or chapter dropdown):
+1. `dispatch(setScope(newScope))` + `dispatch(clearFocus())` — these should fire together (single thunk or combined action)
+2. TanStack Query detects the new scope key and refetches the graph and graph-level metrics
+3. Entity panel drops to the stats/unfocused view
+4. `colorMap` should be recomputed from the new graph's entity types
+5. All cached node metric query results for the old scope remain in TanStack Query cache; results for the new scope will be fetched fresh on demand
+
+---
+
+## 6. Graph panel
+
+### Library
+`react-force-graph-2d`. The component accepts `graphData={{ nodes, links }}` directly matching the API response shape. The library mutates node objects in place during simulation, adding `x`, `y`, `vx`, `vy` — this is expected and useful.
+
+### Node rendering — size
+
+Node size is controlled by `nodeSizeMetric` from Redux. The pipeline:
+
+1. If `nodeSizeMetric === 'occurrence_count'`: use `node.occurrence_count` directly (original behavior)
+2. Otherwise: look up the node's value from the active `NodeMetricResponse.values` dict by UUID, then normalize using the response's `norm_min` / `norm_max` bounds
+
+All size computation lives in a pure utility: `nodeDisplaySize(rawValue, normMin, normMax): number`. The backend always returns `norm_min` and `norm_max` so the frontend never has to compute them across the node set.
+
+**Loading fallback:** while a metric is still loading (TanStack Query `isLoading`, or `status: 'computing'` poll not yet resolved), fall back to `occurrence_count` sizing. No broken or blank state.
+
+### Node rendering — color
+
+Node color is controlled by `nodeColorMetric`. Three cases:
+
+1. **`'entity_type'` (default):** `colorMap[node.entity_type]` — original behavior
+2. **Node-level color metric:** look up value from `NodeMetricResponse.values` by UUID, map through a color scale using `norm_min`/`norm_max`
+3. **Node-pair color metric (only active when `focusEntityId` is non-null):** look up value from `NodePairMetricResponse.values`, map through a color scale
+
+For **community membership** (categorical): assign distinct hues from a fixed palette by community ID. Palette assignment must be deterministic — sort community IDs numerically, assign palette colors in order — so colors don't shuffle on re-render.
+
+For **continuous metrics**: use a color scale appropriate to the metric. The exact scale choices are deferred — implement as a utility `metricToColor(value, normMin, normMax, scaleType): string` so the scale can be swapped without touching rendering logic.
+
+**Loading fallback:** while a metric is loading, fall back to `'entity_type'` coloring.
+
+**Metric values always come from the full-scope graph, regardless of display mode.** When the graph panel is showing an N-hop subgraph, it looks up each displayed node's metric value from the full-graph metric response by UUID. The frontend never needs to request or hold the full graph data structure itself for this — only the `values` dict from the metric response.
+
+### Edge rendering
+- Directed arrows (the library supports this natively)
+- Hover → show tooltip with `link.relationship_type` and `link.description`
+- First-order edges from focus node are visually highlighted (already implemented)
+- Relationship type text on edges: deferred
+
+### Node interactions
+- **Hover:** show tooltip with `node.aliases` (if any), plus current metric value if a non-default metric is active
+- **Click:** `dispatch(setFocus(node.id))`
+- **Click canvas background:** `dispatch(clearFocus())`
+- Standard pan, drag-node, zoom built into the library
+- Leaf node trimming toggle already implemented
+
+### Position persistence (future / nice-to-have)
+Not required at launch. Stub the position cache (`Map<nodeId, {x, y}>`) so it's easy to wire up later.
+
+---
+
+## 7. Entity panel
+
+### Unfocused state
+
+Two sections:
+
+**Graph-level metrics** (from `useGraphMetricsQuery`): show all fields from `GraphMetricsResponse`. Show a loading skeleton while computing. This is the primary content of the unfocused panel — it replaces the "graph stats stub" from the previous spec version.
+
+**Node/edge counts**: `node_count` and `edge_count` from `GraphResponse`, always available immediately.
+
+### Focused state
+Entity card:
+- Name + entity type badge
+- Aliases
+- Description
+- Relationships list — direction, type, description, other entity label as a clickable link → full focus
+
+### Unfocus button
+Visible only when `focusEntityId` is non-null. Dispatches `clearFocus()`.
+
+---
+
+## 8. Top bar components
+
+### Search
+- Fires on **enter key**
+- Dropdown of results while input is focused and `searchResults` is non-empty
+- Results persist in Redux until new search
+- Selecting a result: `dispatch(setFocus(result.id))` + `dispatch(setDisplayMode('nhop'))`
+- 5–10 results, no pagination initially
+- Filters: entity type (multi-select), relationship type (multi-select)
+
+### Scope selectors
+- Dropdown 1: Book ("Full volume" + book titles)
+- Dropdown 2: Chapter (disabled when "Full volume" selected)
+- On change: combined scope-change + clear-focus action (§5)
+
+### Node size metric selector
+Options:
+- Occurrence count *(default)*
+- Degree centrality
+- Betweenness centrality
+- PageRank *(parametric: damping factor, default 0.85)*
+- Closeness centrality
+- K-core number
+
+### Node color metric selector
+Two groups:
+
+**Always available:**
+- Entity type *(default)*
+- Community — Leiden
+- Community — Girvan-Newman
+- Community — Label Propagation
+- Community — Spectral *(parametric: k, number of clusters)*
+- Local clustering coefficient
+- K-core number
+
+**Focus-relative** (grayed out with tooltip "select a focus node first" when `focusEntityId` is null):
+- Cosine similarity
+- Jaccard similarity
+- Adamic-Adar index
+- Common neighbor count
+- Shortest path length
+- Resistance distance
+
+When focus is cleared while a focus-relative metric is selected, the color display falls back to `'entity_type'`. The dropdown selection is preserved in Redux and reactivates on next focus.
+
+### Parameter inputs
+Shown inline in the top bar when a parametric metric is active (small number input adjacent to the metric dropdown).
+
+- **Apply triggers:** enter key OR blur (tab away) — consistent with search UX
+- Each `(scope, metric, params)` combination is a separate TanStack Query cache entry and a separate server-side cache entry
+- Show a loading indicator on the metric selector while the new param combination is computing
+
+### Controls
+- N-hop toggle
+- Hop count (1/2/3), grayed out when N-hop off, default **2**
+- Back/Forward buttons (lower priority)
+
+---
+
+## 9. Metric computation architecture
+
+### Core principle
+All metrics are computed on the **full scope graph**, never on N-hop subgraphs. Metrics are computed **lazily on first request** for a given `(scope, metric, params)` combination, then cached server-side indefinitely (until server restart).
+
+### Server-side cache
+In-memory on the FastAPI process. Cache key:
+```
+(scope_type, book_id, chapter_id, metric_name, **sorted_params)
+```
+Each param combination is a separate cache entry. No Redis required.
+
+### Async response pattern
+For slow metrics (betweenness centrality, some community detection methods):
+
+- Result in cache → `200` with data immediately
+- Computation in progress → `202 Accepted` with `{ status: "computing", metric, params }`
+- Not yet started → start background task, return `202` immediately
+
+Frontend polls with TanStack Query `refetchInterval` while status is `202`; stops on `200`.
+
+Fast metrics (degree, k-core, Jaccard, Adamic-Adar, common neighbors, shortest path) always return `200` synchronously.
+
+### Graph-level metrics trigger
+The first `/graph` call for a scope triggers a background task to compute `GraphMetricsResponse`. The graph endpoint returns immediately; `/metrics/graph` will return `202` briefly then `200` when ready.
+
+---
+
+## 10. DTOs
+
+Frontend TypeScript types should mirror these Pydantic models exactly.
+
+### Shared
+
+```python
+class EntityType(str, Enum):
+    # Values to match KG schema entity types
+    pass
+
+class ScopeType(str, Enum):
+    VOLUME = "volume"
+    BOOK = "book"
+    CHAPTER = "chapter"
+
+class Scope(BaseModel):
+    type: ScopeType
+    book_id: str | None = None
+    chapter_id: str | None = None
+```
+
+### Graph response
+
+```python
+class GraphNode(BaseModel):
+    id: str
+    label: str
+    entity_type: EntityType
+    occurrence_count: int
+    aliases: list[str] = []
+
+class GraphLink(BaseModel):
+    source: str          # entity UUID
+    target: str          # entity UUID
+    relationship_type: str
+    description: str = ""
+
+class GraphResponse(BaseModel):
+    nodes: list[GraphNode]
+    links: list[GraphLink]
+    scope: Scope
+    node_count: int
+    edge_count: int
+```
+
+### Entity detail
+
+```python
+class RelationshipSummary(BaseModel):
+    relationship_id: str
+    relationship_type: str
+    description: str
+    direction: Literal["outgoing", "incoming"]
+    other_entity_id: str
+    other_entity_label: str    # denormalized
+
+class EntityDetail(BaseModel):
+    id: str
+    label: str
+    entity_type: EntityType
+    aliases: list[str]
+    description: str
+    occurrence_count: int
+    relationships: list[RelationshipSummary]
+```
+
+### Search
+
+```python
+class SearchFilters(BaseModel):
+    entity_types: list[EntityType] = []
+    relationship_types: list[str] = []
+
+class SearchResult(BaseModel):
+    id: str
+    label: str
+    entity_type: EntityType
+    aliases: list[str]
+    score: float
+
+class SearchResponse(BaseModel):
+    results: list[SearchResult]
+    query: str
+```
+
+### Scope / navigation
+
+```python
+class ChapterMeta(BaseModel):
+    id: str
+    title: str
+    number: int
+
+class BookMeta(BaseModel):
+    id: str
+    title: str
+    chapters: list[ChapterMeta]
+
+class BooksResponse(BaseModel):
+    books: list[BookMeta]
+```
+
+### Graph-level metrics
+
+```python
+class GraphMetricsResponse(BaseModel):
+    scope: Scope
+    density: float
+    giant_component_ratio: float
+    num_connected_components: int
+    avg_shortest_path_length: float | None  # None if too large to compute
+    diameter: int | None                    # None if too large to compute
+    global_clustering_coefficient: float
+    num_communities: int                    # from default community detection method
+    articulation_point_count: int
+    status: Literal["ready", "computing"]
+```
+
+### Node-level metrics
+
+```python
+class NodeMetricResponse(BaseModel):
+    scope: Scope
+    metric: str
+    params: dict[str, float] = {}
+    values: dict[str, float]       # entity UUID → metric value
+    norm_min: float
+    norm_max: float
+    status: Literal["ready", "computing"]
+
+class CommunityMetricResponse(BaseModel):
+    """For categorical community membership metrics."""
+    scope: Scope
+    metric: str
+    params: dict[str, float] = {}
+    values: dict[str, int]         # entity UUID → community ID
+    num_communities: int
+    status: Literal["ready", "computing"]
+```
+
+### Node-pair metrics
+
+```python
+class NodePairMetricResponse(BaseModel):
+    scope: Scope
+    focus_entity_id: str
+    metric: str
+    params: dict[str, float] = {}
+    values: dict[str, float]       # entity UUID → value relative to focus node
+    norm_min: float
+    norm_max: float
+    # No status field — all node-pair metrics return synchronously
+```
+
+### Metric name enums
+
+```python
+class NodeSizeMetric(str, Enum):
+    OCCURRENCE_COUNT = "occurrence_count"
+    DEGREE_CENTRALITY = "degree_centrality"
+    BETWEENNESS_CENTRALITY = "betweenness_centrality"
+    PAGERANK = "pagerank"                       # params: damping (default 0.85)
+    CLOSENESS_CENTRALITY = "closeness_centrality"
+    KCORE_NUMBER = "kcore_number"
+
+class NodeColorMetric(str, Enum):
+    ENTITY_TYPE = "entity_type"
+    COMMUNITY_LEIDEN = "community_leiden"
+    COMMUNITY_GIRVAN_NEWMAN = "community_girvan_newman"
+    COMMUNITY_LABEL_PROPAGATION = "community_label_propagation"
+    COMMUNITY_SPECTRAL = "community_spectral"   # params: k (number of clusters)
+    LOCAL_CLUSTERING_COEFFICIENT = "local_clustering_coefficient"
+    KCORE_NUMBER = "kcore_number"
+
+class NodePairMetric(str, Enum):
+    COSINE_SIMILARITY = "cosine_similarity"     # backend fetches Weaviate vectors; never shipped to frontend
+    JACCARD_SIMILARITY = "jaccard_similarity"
+    ADAMIC_ADAR = "adamic_adar"
+    COMMON_NEIGHBOR_COUNT = "common_neighbor_count"
+    SHORTEST_PATH_LENGTH = "shortest_path_length"
+    RESISTANCE_DISTANCE = "resistance_distance"
+```
+
+---
+
+## 11. API contract
+
+All endpoints under `/api/v1/`.
+
+### Existing endpoints (unchanged)
+
+```
+GET  /api/v1/graph
+     ?scope_type=volume|book|chapter  &book_id=<uuid>  &chapter_id=<uuid>
+     → GraphResponse
+     Side effect: triggers background computation of GraphMetricsResponse for this scope
+
+GET  /api/v1/graph/subgraph
+     ?entity_id=<uuid>  &hops=1|2|3
+     ?scope_type=...  &book_id=<uuid>  &chapter_id=<uuid>
+     → GraphResponse
+
+GET  /api/v1/entities/{entity_id}
+     → EntityDetail
+
+POST /api/v1/search
+     body: { query: str, filters: SearchFilters, scope: Scope, limit: int = 10 }
+     → SearchResponse
+
+GET  /api/v1/books
+     → BooksResponse
+```
+
+### New metric endpoints
+
+```
+GET  /api/v1/metrics/graph
+     ?scope_type=...  &book_id=<uuid>  &chapter_id=<uuid>
+     → GraphMetricsResponse
+     202 if background task not yet complete
+
+GET  /api/v1/metrics/node
+     ?scope_type=...  &book_id=<uuid>  &chapter_id=<uuid>
+     ?metric=<NodeSizeMetric | NodeColorMetric>
+     ?damping=0.85        (PageRank only)
+     ?k=4                 (spectral clustering only)
+     → NodeMetricResponse | CommunityMetricResponse
+     202 if not yet cached; cache key: (scope, metric, **params)
+
+GET  /api/v1/metrics/node-pair
+     ?scope_type=...  &book_id=<uuid>  &chapter_id=<uuid>
+     ?focus_entity_id=<uuid>
+     ?metric=<NodePairMetric>
+     → NodePairMetricResponse
+     Always 200 synchronously
+```
+
+---
+
+## 12. Key design decisions (summary)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| State management | Redux (UI) + TanStack Query (server) | Complementary. Redux owns user choices; TQ owns fetched data and caching. |
+| Graph library | `react-force-graph-2d` | Most mature 2D force graph lib for React. |
+| Graph building | Backend-only | All assembly, N-hop traversal, preprocessing in Python/NetworkX. |
+| Subgraph response shape | Same as full graph (`GraphResponse`) | Component doesn't need to know which it received. |
+| `occurrence_count` scaling | Frontend utility function | Display concern — easy to tune without touching backend. |
+| `other_entity_label` on `RelationshipSummary` | Denormalized | Avoids N+1 requests in entity panel. |
+| `source`/`target` on `GraphLink` | UUIDs (strings) | react-force-graph resolves internally. |
+| Scope change | Clears focus, loads new graph | Graphs are pre-built per scope; this is a load, not a filter. |
+| Clear focus | Also resets to full-graph mode | N-hop without focus is meaningless. |
+| Search results | Redux (not TQ) | Triggered imperatively (enter key), not reactively. |
+| Position persistence | Deferred | Stub the cache now; wire up later. |
+| Mobile/responsive | Not in scope | Desktop-only. |
+| Metric computation scope | Always full scope graph | N-hop subgraph is a display artifact; metrics on it would be misleading. |
+| Metric values in N-hop mode | UUID lookup from full-graph metric response | Transparent regardless of display mode; no full graph data needed on frontend. |
+| Metric fetch strategy | Independent per-metric requests | Size and color fetched separately; changing one doesn't invalidate the other. |
+| Server-side metric cache | In-memory, keyed by `(scope, metric, params)` | Each param combination is a separate entry. No Redis needed. |
+| Metric compute timing | Lazy on first request; graph-level as background side effect of `/graph` | No eager startup precompute. |
+| Slow metric UX | Progressive enhancement with 202 polling | Graph renders immediately; size/color updates when ready. Falls back to defaults while loading. |
+| Cosine similarity | Backend only | Weaviate vectors never shipped to frontend. |
+| Parametric metric apply | Enter key or blur | Consistent with search UX; explicit, no debounce needed. |
+| Focus-relative metrics when focus cleared | Silent fallback to entity_type; selection preserved | Reactivates automatically on next focus set. |
+| Community color palette | Deterministic by sorted community ID | Prevents color shuffling on re-render. |
+
+---
+
+## 13. Out of scope / deferred
+
+- **Node position persistence:** Stub the position cache (`Map<nodeId, {x, y}>`); implement later.
+- **Relationship type text on edges:** Start with nothing; add later.
+- **Back/forward history:** Scaffold Redux state and buttons; full implementation lower priority.
+- **Force simulation customization:** Start with react-force-graph defaults; iterate later.
+- **Node size scaling formula:** Implement as `nodeDisplaySize(rawValue, normMin, normMax)` utility; exact formula (sqrt vs log, ceiling) is a runtime tuning decision.
+- **Color scale choices for continuous metrics:** Implement `metricToColor(value, normMin, normMax, scaleType)` as a swappable utility; specific scale choices deferred.
+- **Richer graph stats in entity panel:** Node/edge counts shown now; degree distribution, most-connected nodes, etc. are a separate workstream.
+- **Resistance distance at launch:** Computationally expensive (matrix inversion on full graph). Include in the API contract but Claude Code should assess feasibility against actual graph sizes before implementing.
+- **Metric value display in entity panel for node-pair metrics:** Whether to show focused node's self-similarity as a reference point is deferred.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,6 +31,9 @@
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
+      },
+      "devDependencies": {
+        "@types/d3-scale-chromatic": "^3.1.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4011,6 +4014,13 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/eslint": {
       "version": "8.56.12",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,5 +50,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@types/d3-scale-chromatic": "^3.1.0"
   }
 }

--- a/frontend/src/components/kg/EntityPanel.tsx
+++ b/frontend/src/components/kg/EntityPanel.tsx
@@ -10,6 +10,7 @@ import {
   CircularProgress,
   Tooltip,
   Button,
+  Skeleton,
 } from '@mui/material';
 import {
   ArrowForward as OutgoingIcon,
@@ -19,13 +20,15 @@ import {
 import { useAppDispatch, useAppSelector } from '../../store';
 import { setFocus, clearFocus } from '../../store/graphSlice';
 import { useEntityQuery } from '../../hooks/useKGQueries';
-import { GraphResponse, ENTITY_TYPE_COLORS } from '../../types/kg';
+import { GraphMetricsResponse, GraphResponse, ENTITY_TYPE_COLORS } from '../../types/kg';
 
 interface EntityPanelProps {
   activeGraph: GraphResponse | undefined;
+  graphMetrics?: GraphMetricsResponse;
+  graphMetricsLoading?: boolean;
 }
 
-const EntityPanel: React.FC<EntityPanelProps> = ({ activeGraph }) => {
+const EntityPanel: React.FC<EntityPanelProps> = ({ activeGraph, graphMetrics, graphMetricsLoading }) => {
   const dispatch = useAppDispatch();
   const { focusEntityId, colorMap } = useAppSelector((s) => s.graph);
 
@@ -35,42 +38,99 @@ const EntityPanel: React.FC<EntityPanelProps> = ({ activeGraph }) => {
     colorMap[type] ?? ENTITY_TYPE_COLORS[type] ?? '#999';
 
   if (!focusEntityId) {
-    // Unfocused state: show graph stats
+    // Unfocused state: show graph stats + network metrics
+    const showMetrics = activeGraph != null;
+    const isComputingMetrics = graphMetricsLoading || graphMetrics?.status === 'computing';
+
+    const MetricRow: React.FC<{ label: string; value: React.ReactNode }> = ({ label, value }) => (
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', py: 0.4 }}>
+        <Typography variant="caption" color="text.secondary">{label}</Typography>
+        <Typography variant="caption" fontWeight="bold">
+          {isComputingMetrics ? <Skeleton width={48} /> : value}
+        </Typography>
+      </Box>
+    );
+
     return (
       <Box sx={{ p: 2, height: '100%', overflow: 'auto' }}>
         <Typography variant="subtitle2" color="text.secondary" gutterBottom>
-          Graph Stats
+          Graph Metrics
         </Typography>
-        {activeGraph ? (
-          <>
-            <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
-              <Box>
-                <Typography variant="h5" fontWeight="bold">
-                  {activeGraph.node_count}
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  Entities
-                </Typography>
-              </Box>
-              <Box>
-                <Typography variant="h5" fontWeight="bold">
-                  {activeGraph.edge_count}
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  Relationships
-                </Typography>
-              </Box>
-            </Box>
-            <Divider sx={{ mb: 2 }} />
-            <Typography variant="caption" color="text.secondary">
-              Click a node to explore entity details. Use N-hop mode to focus on a
-              subgraph around a selected entity.
-            </Typography>
-          </>
-        ) : (
+        {!showMetrics ? (
           <Typography variant="caption" color="text.secondary">
             Select a graph to begin.
           </Typography>
+        ) : (
+          <>
+            {/* Counts — always available from graph data */}
+            <Box sx={{ display: 'flex', gap: 3, mb: 1.5 }}>
+              <Box>
+                <Typography variant="h5" fontWeight="bold">{activeGraph.node_count.toLocaleString()}</Typography>
+                <Typography variant="caption" color="text.secondary">Entities</Typography>
+              </Box>
+              <Box>
+                <Typography variant="h5" fontWeight="bold">{activeGraph.edge_count.toLocaleString()}</Typography>
+                <Typography variant="caption" color="text.secondary">Relationships</Typography>
+              </Box>
+            </Box>
+            <Divider sx={{ mb: 1 }} />
+
+            {/* Network metrics */}
+            <MetricRow
+              label="Density"
+              value={graphMetrics ? graphMetrics.density.toFixed(4) : '—'}
+            />
+            <MetricRow
+              label="Giant component"
+              value={graphMetrics ? `${(graphMetrics.giant_component_ratio * 100).toFixed(1)}%` : '—'}
+            />
+            <MetricRow
+              label="Components"
+              value={graphMetrics?.num_connected_components ?? '—'}
+            />
+            <MetricRow
+              label="Avg path length"
+              value={
+                graphMetrics
+                  ? (graphMetrics.avg_shortest_path_length != null
+                    ? graphMetrics.avg_shortest_path_length.toFixed(2)
+                    : 'too large')
+                  : '—'
+              }
+            />
+            <MetricRow
+              label="Diameter"
+              value={
+                graphMetrics
+                  ? (graphMetrics.diameter != null ? graphMetrics.diameter : 'too large')
+                  : '—'
+              }
+            />
+            <MetricRow
+              label="Clustering coeff."
+              value={graphMetrics ? graphMetrics.global_clustering_coefficient.toFixed(3) : '—'}
+            />
+            <MetricRow
+              label="Communities (Louvain)"
+              value={graphMetrics?.num_communities ?? '—'}
+            />
+            <MetricRow
+              label="Articulation points"
+              value={graphMetrics?.articulation_point_count ?? '—'}
+            />
+
+            {isComputingMetrics && (
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 1 }}>
+                <CircularProgress size={12} />
+                <Typography variant="caption" color="text.secondary">Computing…</Typography>
+              </Box>
+            )}
+
+            <Divider sx={{ my: 1.5 }} />
+            <Typography variant="caption" color="text.secondary">
+              Click a node to explore entity details.
+            </Typography>
+          </>
         )}
       </Box>
     );

--- a/frontend/src/components/kg/ForceGraphPanel.tsx
+++ b/frontend/src/components/kg/ForceGraphPanel.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import ForceGraph2D from 'react-force-graph-2d';
+import { interpolateViridis } from 'd3-scale-chromatic';
 import { Box, CircularProgress, Typography } from '@mui/material';
 import { useAppDispatch, useAppSelector } from '../../store';
 import { setFocus, clearFocus } from '../../store/graphSlice';
@@ -28,13 +29,10 @@ function nodeDisplaySize(
   return 4 + t * 16;
 }
 
-// Utility: continuous metric value → hex color (cool blue-purple scale)
+// Utility: continuous metric value → color using viridis (perceptually uniform, colorblind-safe)
 function metricToColor(value: number, normMin: number, normMax: number): string {
   const t = normMax > normMin ? (value - normMin) / (normMax - normMin) : 0.5;
-  const r = Math.round(50 + (1 - t) * 170);
-  const g = Math.round(50 + (1 - t) * 120);
-  const b = Math.round(200 + t * 55);
-  return `rgb(${r},${g},${b})`;
+  return interpolateViridis(Math.max(0, Math.min(1, t)));
 }
 
 // Utility: community ID → hex color (deterministic)

--- a/frontend/src/components/kg/ForceGraphPanel.tsx
+++ b/frontend/src/components/kg/ForceGraphPanel.tsx
@@ -31,7 +31,7 @@ function nodeDisplaySize(
 
 // Utility: continuous metric value → color using viridis (perceptually uniform, colorblind-safe)
 function metricToColor(value: number, normMin: number, normMax: number): string {
-  const t = normMax > normMin ? (value - normMin) / (normMax - normMin) : 0.5;
+  const t = normMax !== normMin ? (value - normMin) / (normMax - normMin) : 0.5;
   return interpolateViridis(Math.max(0, Math.min(1, t)));
 }
 

--- a/frontend/src/components/kg/ForceGraphPanel.tsx
+++ b/frontend/src/components/kg/ForceGraphPanel.tsx
@@ -5,6 +5,7 @@ import { Box, CircularProgress, Typography } from '@mui/material';
 import { useAppDispatch, useAppSelector } from '../../store';
 import { setFocus, clearFocus } from '../../store/graphSlice';
 import { GraphResponse, GraphNode, ENTITY_TYPE_COLORS } from '../../types/kg';
+import LegendOverlay from './LegendOverlay';
 
 // Deterministic community color palette (sorted community IDs → palette index)
 const COMMUNITY_PALETTE = [
@@ -63,6 +64,8 @@ interface ForceGraphPanelProps {
   colorNormMax?: number;
   // Color metric data — community (categorical)
   communityValues?: Record<string, number>;
+  // Label shown in legend (human-readable metric name)
+  colorMetricLabel?: string;
 }
 
 const ForceGraphPanel: React.FC<ForceGraphPanelProps> = ({
@@ -75,6 +78,7 @@ const ForceGraphPanel: React.FC<ForceGraphPanelProps> = ({
   colorNormMin = 0,
   colorNormMax = 1,
   communityValues,
+  colorMetricLabel,
 }) => {
   const dispatch = useAppDispatch();
   const { focusEntityId, colorMap } = useAppSelector((s) => s.graph);
@@ -220,8 +224,20 @@ const ForceGraphPanel: React.FC<ForceGraphPanelProps> = ({
     );
   }
 
+  const legendMode = communityValues != null
+    ? null
+    : colorMetricValues != null
+      ? 'continuous'
+      : 'entity_type';
+
   return (
     <Box ref={containerRef} sx={{ flex: 1, overflow: 'hidden', position: 'relative' }}>
+      <LegendOverlay
+        mode={legendMode as 'entity_type' | 'continuous' | null}
+        colorNormMin={colorNormMin}
+        colorNormMax={colorNormMax}
+        label={colorMetricLabel}
+      />
       <ForceGraph2D
         ref={graphRef}
         graphData={graphData as any}

--- a/frontend/src/components/kg/ForceGraphPanel.tsx
+++ b/frontend/src/components/kg/ForceGraphPanel.tsx
@@ -5,9 +5,42 @@ import { useAppDispatch, useAppSelector } from '../../store';
 import { setFocus, clearFocus } from '../../store/graphSlice';
 import { GraphResponse, GraphNode, ENTITY_TYPE_COLORS } from '../../types/kg';
 
-// Utility: map occurrence_count to node display radius
-function nodeSize(occurrenceCount: number): number {
+// Deterministic community color palette (sorted community IDs → palette index)
+const COMMUNITY_PALETTE = [
+  '#4e79a7', '#f28e2b', '#59a14f', '#e15759', '#b07aa1',
+  '#76b7b2', '#edc948', '#ff9da7', '#9c755f', '#bab0ac',
+];
+
+// Utility: map occurrence_count to node display radius (fallback)
+function occurrenceNodeSize(occurrenceCount: number): number {
   return Math.max(4, Math.log(occurrenceCount + 1) * 3);
+}
+
+// Utility: metric value → node radius (4–20px range)
+function nodeDisplaySize(
+  occurrenceCount: number,
+  metricValue: number | undefined,
+  normMin: number,
+  normMax: number
+): number {
+  if (metricValue === undefined) return occurrenceNodeSize(occurrenceCount);
+  const t = normMax > normMin ? (metricValue - normMin) / (normMax - normMin) : 0.5;
+  return 4 + t * 16;
+}
+
+// Utility: continuous metric value → hex color (cool blue-purple scale)
+function metricToColor(value: number, normMin: number, normMax: number): string {
+  const t = normMax > normMin ? (value - normMin) / (normMax - normMin) : 0.5;
+  const r = Math.round(50 + (1 - t) * 170);
+  const g = Math.round(50 + (1 - t) * 120);
+  const b = Math.round(200 + t * 55);
+  return `rgb(${r},${g},${b})`;
+}
+
+// Utility: community ID → hex color (deterministic)
+function communityToColor(communityId: number, sortedCommunityIds: number[]): string {
+  const idx = sortedCommunityIds.indexOf(communityId);
+  return COMMUNITY_PALETTE[Math.max(0, idx) % COMMUNITY_PALETTE.length];
 }
 
 // After the force simulation runs, link.source/target mutate from string IDs to node objects.
@@ -22,11 +55,38 @@ function linkNodeId(endpoint: unknown): string {
 interface ForceGraphPanelProps {
   graphData: GraphResponse | undefined;
   isLoading: boolean;
+  // Size metric data (undefined = use occurrence_count fallback)
+  sizeMetricValues?: Record<string, number>;
+  sizeNormMin?: number;
+  sizeNormMax?: number;
+  // Color metric data — continuous
+  colorMetricValues?: Record<string, number>;
+  colorNormMin?: number;
+  colorNormMax?: number;
+  // Color metric data — community (categorical)
+  communityValues?: Record<string, number>;
 }
 
-const ForceGraphPanel: React.FC<ForceGraphPanelProps> = ({ graphData, isLoading }) => {
+const ForceGraphPanel: React.FC<ForceGraphPanelProps> = ({
+  graphData,
+  isLoading,
+  sizeMetricValues,
+  sizeNormMin = 0,
+  sizeNormMax = 1,
+  colorMetricValues,
+  colorNormMin = 0,
+  colorNormMax = 1,
+  communityValues,
+}) => {
   const dispatch = useAppDispatch();
   const { focusEntityId, colorMap } = useAppSelector((s) => s.graph);
+
+  // Pre-compute sorted community IDs for deterministic color assignment
+  const sortedCommunityIds = useMemo((): number[] => {
+    if (!communityValues) return [];
+    const unique = Array.from(new Set(Object.values(communityValues)));
+    return unique.sort((a, b) => a - b);
+  }, [communityValues]);
   const containerRef = useRef<HTMLDivElement>(null);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const graphRef = useRef<any>(null);
@@ -68,8 +128,24 @@ const ForceGraphPanel: React.FC<ForceGraphPanelProps> = ({ graphData, isLoading 
   const nodeCanvasObject = useCallback(
     (node: GraphNode, ctx: CanvasRenderingContext2D, globalScale: number) => {
       const { x, y } = node as { x: number; y: number };
-      const radius = nodeSize(node.occurrence_count);
-      const color = colorMap[node.entity_type] ?? ENTITY_TYPE_COLORS[node.entity_type] ?? '#999';
+
+      // --- Node size ---
+      const radius = nodeDisplaySize(
+        node.occurrence_count,
+        sizeMetricValues?.[node.id],
+        sizeNormMin,
+        sizeNormMax
+      );
+
+      // --- Node color (precedence: community > continuous > entity_type) ---
+      let color: string;
+      if (communityValues?.[node.id] !== undefined) {
+        color = communityToColor(communityValues[node.id], sortedCommunityIds);
+      } else if (colorMetricValues?.[node.id] !== undefined) {
+        color = metricToColor(colorMetricValues[node.id], colorNormMin, colorNormMax);
+      } else {
+        color = colorMap[node.entity_type] ?? ENTITY_TYPE_COLORS[node.entity_type] ?? '#999';
+      }
 
       const isFocused = node.id === focusEntityId;
       const isNeighbor = neighborIds.has(node.id);
@@ -102,15 +178,25 @@ const ForceGraphPanel: React.FC<ForceGraphPanelProps> = ({ graphData, isLoading 
 
       ctx.globalAlpha = 1;
     },
-    [colorMap, focusEntityId, neighborIds]
+    [
+      colorMap, focusEntityId, neighborIds,
+      sizeMetricValues, sizeNormMin, sizeNormMax,
+      colorMetricValues, colorNormMin, colorNormMax,
+      communityValues, sortedCommunityIds,
+    ]
   );
 
   const nodeLabel = useCallback(
     (node: GraphNode) => {
       const aliasText = node.aliases.length > 0 ? `\nAliases: ${node.aliases.join(', ')}` : '';
-      return `${node.name} (${node.entity_type})${aliasText}`;
+      const sizeVal = sizeMetricValues?.[node.id];
+      const colorVal = colorMetricValues?.[node.id] ?? communityValues?.[node.id];
+      const metricText = (sizeVal !== undefined || colorVal !== undefined)
+        ? `\nSize: ${sizeVal?.toFixed(3) ?? 'occurrence_count'} | Color: ${colorVal?.toFixed(3) ?? 'entity_type'}`
+        : '';
+      return `${node.name} (${node.entity_type})${aliasText}${metricText}`;
     },
-    []
+    [sizeMetricValues, colorMetricValues, communityValues]
   );
 
   const linkLabel = useCallback(
@@ -144,7 +230,10 @@ const ForceGraphPanel: React.FC<ForceGraphPanelProps> = ({ graphData, isLoading 
         nodeId="id"
         linkSource="source"
         linkTarget="target"
-        nodeVal={(node) => nodeSize((node as GraphNode).occurrence_count)}
+        nodeVal={(node) => {
+          const n = node as GraphNode;
+          return nodeDisplaySize(n.occurrence_count, sizeMetricValues?.[n.id], sizeNormMin, sizeNormMax);
+        }}
         nodeCanvasObject={nodeCanvasObject as any}
         nodeCanvasObjectMode={() => 'replace'}
         nodeLabel={nodeLabel as any}

--- a/frontend/src/components/kg/KGTopBar.tsx
+++ b/frontend/src/components/kg/KGTopBar.tsx
@@ -367,47 +367,53 @@ const KGTopBar: React.FC = () => {
       </Box>
 
       {/* N-hop toggle */}
-      <ToggleButtonGroup
-        size="small"
-        exclusive
-        value={displayMode}
-        onChange={(_e, val) => val && dispatch(setDisplayMode(val))}
-      >
-        <ToggleButton value="full">Full</ToggleButton>
-        <ToggleButton value="nhop">N-hop</ToggleButton>
-      </ToggleButtonGroup>
+      <Tooltip title="Full: show the entire graph. N-hop: show only the focused entity and nodes within N edges of it.">
+        <ToggleButtonGroup
+          size="small"
+          exclusive
+          value={displayMode}
+          onChange={(_e, val) => val && dispatch(setDisplayMode(val))}
+        >
+          <ToggleButton value="full">Full</ToggleButton>
+          <ToggleButton value="nhop">N-hop</ToggleButton>
+        </ToggleButtonGroup>
+      </Tooltip>
 
       {/* Hop count */}
-      <FormControl size="small" sx={{ minWidth: 80 }}>
-        <InputLabel>Hops</InputLabel>
-        <Select
-          label="Hops"
-          value={hopCount}
-          onChange={(e) => dispatch(setHopCount(Number(e.target.value) as 1 | 2 | 3))}
-          disabled={displayMode !== 'nhop'}
-        >
-          <MenuItem value={1}>1</MenuItem>
-          <MenuItem value={2}>2</MenuItem>
-          <MenuItem value={3}>3</MenuItem>
-        </Select>
-      </FormControl>
+      <Tooltip title="Maximum number of edges between the focused entity and any displayed node.">
+        <FormControl size="small" sx={{ minWidth: 80 }}>
+          <InputLabel>Hops</InputLabel>
+          <Select
+            label="Hops"
+            value={hopCount}
+            onChange={(e) => dispatch(setHopCount(Number(e.target.value) as 1 | 2 | 3))}
+            disabled={displayMode !== 'nhop'}
+          >
+            <MenuItem value={1}>1</MenuItem>
+            <MenuItem value={2}>2</MenuItem>
+            <MenuItem value={3}>3</MenuItem>
+          </Select>
+        </FormControl>
+      </Tooltip>
 
       {/* Occurrence threshold slider */}
-      <Box sx={{ display: 'flex', flexDirection: 'column', width: 140, px: 1 }}>
-        <Typography variant="caption" color="text.secondary" sx={{ lineHeight: 1 }}>
-          Min. occurrences: {occurrenceThreshold === 1 ? 'all' : `≥ ${occurrenceThreshold}`}
-        </Typography>
-        <Slider
-          size="small"
-          min={1}
-          max={4}
-          step={1}
-          value={occurrenceThreshold}
-          onChange={(_e, val) => dispatch(setOccurrenceThreshold(val as number))}
-          marks
-          sx={{ py: 0.5 }}
-        />
-      </Box>
+      <Tooltip title="Hide entities mentioned fewer than this many times in the source text.">
+        <Box sx={{ display: 'flex', flexDirection: 'column', width: 140, px: 1 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ lineHeight: 1 }}>
+            Min. occurrences: {occurrenceThreshold === 1 ? 'all' : `≥ ${occurrenceThreshold}`}
+          </Typography>
+          <Slider
+            size="small"
+            min={1}
+            max={4}
+            step={1}
+            value={occurrenceThreshold}
+            onChange={(_e, val) => dispatch(setOccurrenceThreshold(val as number))}
+            marks
+            sx={{ py: 0.5 }}
+          />
+        </Box>
+      </Tooltip>
 
       {/* Leaf trim toggle */}
       <Tooltip title="Recursively remove nodes with only one connection">

--- a/frontend/src/components/kg/KGTopBar.tsx
+++ b/frontend/src/components/kg/KGTopBar.tsx
@@ -338,7 +338,7 @@ const KGTopBar: React.FC = () => {
             <ListSubheader sx={{ fontSize: '0.72rem', lineHeight: '1.6' }}>
               Focus-relative (select a node first)
             </ListSubheader>
-            {(NODE_PAIR_METRICS as string[]).filter((m) => m !== 'resistance_distance').map((m) => (
+            {(NODE_PAIR_METRICS as string[]).map((m) => (
               <MenuItem
                 key={m}
                 value={m}

--- a/frontend/src/components/kg/KGTopBar.tsx
+++ b/frontend/src/components/kg/KGTopBar.tsx
@@ -92,11 +92,11 @@ const KGTopBar: React.FC = () => {
   const isNodePairColorMetric = NODE_PAIR_METRICS.includes(nodeColorMetric as NodePairMetric);
   const sizeMetricQuery = useNodeMetricQuery(
     graphName, nodeSizeMetric, nodeSizeParams,
-    nodeSizeMetric !== 'occurrence_count'
+    nodeSizeMetric !== NodeSizeMetric.OccurrenceCount
   );
   const colorMetricQuery = useNodeMetricQuery(
     graphName, nodeColorMetric as NodeColorMetric, nodeColorParams,
-    !isNodePairColorMetric && nodeColorMetric !== 'entity_type'
+    !isNodePairColorMetric && nodeColorMetric !== NodeColorMetric.EntityType
   );
   const colorPairMetricQuery = useNodePairMetricQuery(
     graphName, focusEntityId, nodeColorMetric as NodePairMetric,
@@ -291,15 +291,15 @@ const KGTopBar: React.FC = () => {
               sizeLoading ? <CircularProgress size={14} sx={{ mr: 2 }} /> : null
             }
           >
-            <MenuItem value="occurrence_count">Occurrence count</MenuItem>
-            <MenuItem value="degree_centrality">Degree centrality</MenuItem>
-            <MenuItem value="betweenness_centrality">Betweenness centrality</MenuItem>
-            <MenuItem value="pagerank">PageRank</MenuItem>
-            <MenuItem value="closeness_centrality">Closeness centrality</MenuItem>
-            <MenuItem value="kcore_number">K-core number</MenuItem>
+            <MenuItem value={NodeSizeMetric.OccurrenceCount}>Occurrence count</MenuItem>
+            <MenuItem value={NodeSizeMetric.DegreeCentrality}>Degree centrality</MenuItem>
+            <MenuItem value={NodeSizeMetric.BetweennessCentrality}>Betweenness centrality</MenuItem>
+            <MenuItem value={NodeSizeMetric.PageRank}>PageRank</MenuItem>
+            <MenuItem value={NodeSizeMetric.ClosenessCentrality}>Closeness centrality</MenuItem>
+            <MenuItem value={NodeSizeMetric.KCoreNumber}>K-core number</MenuItem>
           </Select>
         </FormControl>
-        {nodeSizeMetric === 'pagerank' && (
+        {nodeSizeMetric === NodeSizeMetric.PageRank && (
           <Tooltip title="Damping factor (0–1)">
             <TextField
               size="small"
@@ -328,13 +328,13 @@ const KGTopBar: React.FC = () => {
               colorLoading ? <CircularProgress size={14} sx={{ mr: 2 }} /> : null
             }
           >
-            <MenuItem value="entity_type">Entity type</MenuItem>
-            <MenuItem value="community_louvain">Community — Louvain</MenuItem>
-            <MenuItem value="community_girvan_newman">Community — Girvan-Newman</MenuItem>
-            <MenuItem value="community_label_propagation">Community — Label prop.</MenuItem>
-            <MenuItem value="community_spectral">Community — Spectral</MenuItem>
-            <MenuItem value="local_clustering_coefficient">Local clustering coeff.</MenuItem>
-            <MenuItem value="kcore_number">K-core number</MenuItem>
+            <MenuItem value={NodeColorMetric.EntityType}>Entity type</MenuItem>
+            <MenuItem value={NodeColorMetric.CommunityLouvain}>Community — Louvain</MenuItem>
+            <MenuItem value={NodeColorMetric.CommunityGirvanNewman}>Community — Girvan-Newman</MenuItem>
+            <MenuItem value={NodeColorMetric.CommunityLabelPropagation}>Community — Label prop.</MenuItem>
+            <MenuItem value={NodeColorMetric.CommunitySpectral}>Community — Spectral</MenuItem>
+            <MenuItem value={NodeColorMetric.LocalClusteringCoefficient}>Local clustering coeff.</MenuItem>
+            <MenuItem value={NodeColorMetric.KCoreNumber}>K-core number</MenuItem>
             <ListSubheader sx={{ fontSize: '0.72rem', lineHeight: '1.6' }}>
               Focus-relative (select a node first)
             </ListSubheader>
@@ -349,7 +349,7 @@ const KGTopBar: React.FC = () => {
             ))}
           </Select>
         </FormControl>
-        {nodeColorMetric === 'community_spectral' && (
+        {nodeColorMetric === NodeColorMetric.CommunitySpectral && (
           <Tooltip title="Number of clusters (k ≥ 2)">
             <TextField
               size="small"

--- a/frontend/src/components/kg/KGTopBar.tsx
+++ b/frontend/src/components/kg/KGTopBar.tsx
@@ -52,6 +52,7 @@ import {
   KGGraphMeta,
   ENTITY_TYPE_COLORS,
   METRIC_LABELS,
+  METRIC_TOOLTIPS,
   NODE_PAIR_METRICS,
   NodeSizeMetric,
   NodeColorMetric,
@@ -292,12 +293,12 @@ const KGTopBar: React.FC = () => {
               sizeLoading ? <CircularProgress size={14} sx={{ mr: 2 }} /> : null
             }
           >
-            <MenuItem value={NodeSizeMetric.OccurrenceCount}>Occurrence count</MenuItem>
-            <MenuItem value={NodeSizeMetric.DegreeCentrality}>Degree centrality</MenuItem>
-            <MenuItem value={NodeSizeMetric.BetweennessCentrality}>Betweenness centrality</MenuItem>
-            <MenuItem value={NodeSizeMetric.PageRank}>PageRank</MenuItem>
-            <MenuItem value={NodeSizeMetric.ClosenessCentrality}>Closeness centrality</MenuItem>
-            <MenuItem value={NodeSizeMetric.KCoreNumber}>K-core number</MenuItem>
+            <MenuItem value={NodeSizeMetric.OccurrenceCount}><Tooltip title={METRIC_TOOLTIPS[NodeSizeMetric.OccurrenceCount]} placement="right" enterDelay={500}><span>Occurrence count</span></Tooltip></MenuItem>
+            <MenuItem value={NodeSizeMetric.DegreeCentrality}><Tooltip title={METRIC_TOOLTIPS[NodeSizeMetric.DegreeCentrality]} placement="right" enterDelay={500}><span>Degree centrality</span></Tooltip></MenuItem>
+            <MenuItem value={NodeSizeMetric.BetweennessCentrality}><Tooltip title={METRIC_TOOLTIPS[NodeSizeMetric.BetweennessCentrality]} placement="right" enterDelay={500}><span>Betweenness centrality</span></Tooltip></MenuItem>
+            <MenuItem value={NodeSizeMetric.PageRank}><Tooltip title={METRIC_TOOLTIPS[NodeSizeMetric.PageRank]} placement="right" enterDelay={500}><span>PageRank</span></Tooltip></MenuItem>
+            <MenuItem value={NodeSizeMetric.ClosenessCentrality}><Tooltip title={METRIC_TOOLTIPS[NodeSizeMetric.ClosenessCentrality]} placement="right" enterDelay={500}><span>Closeness centrality</span></Tooltip></MenuItem>
+            <MenuItem value={NodeSizeMetric.KCoreNumber}><Tooltip title={METRIC_TOOLTIPS[NodeSizeMetric.KCoreNumber]} placement="right" enterDelay={500}><span>K-core number</span></Tooltip></MenuItem>
           </Select>
         </FormControl>
         {nodeSizeMetric === NodeSizeMetric.PageRank && (
@@ -329,19 +330,21 @@ const KGTopBar: React.FC = () => {
               colorLoading ? <CircularProgress size={14} sx={{ mr: 2 }} /> : null
             }
           >
-            <MenuItem value={NodeColorMetric.EntityType}>{METRIC_LABELS[NodeColorMetric.EntityType]}</MenuItem>
-            <MenuItem value={NodeColorMetric.CommunityLouvain}>{METRIC_LABELS[NodeColorMetric.CommunityLouvain]}</MenuItem>
-            <MenuItem value={NodeColorMetric.CommunityGirvanNewman}>{METRIC_LABELS[NodeColorMetric.CommunityGirvanNewman]}</MenuItem>
-            <MenuItem value={NodeColorMetric.CommunityLabelPropagation}>{METRIC_LABELS[NodeColorMetric.CommunityLabelPropagation]}</MenuItem>
-            <MenuItem value={NodeColorMetric.CommunitySpectral}>{METRIC_LABELS[NodeColorMetric.CommunitySpectral]}</MenuItem>
-            <MenuItem value={NodeColorMetric.LocalClusteringCoefficient}>{METRIC_LABELS[NodeColorMetric.LocalClusteringCoefficient]}</MenuItem>
-            <MenuItem value={NodeColorMetric.KCoreNumber}>{METRIC_LABELS[NodeColorMetric.KCoreNumber]}</MenuItem>
+            <MenuItem value={NodeColorMetric.EntityType}><Tooltip title={METRIC_TOOLTIPS[NodeColorMetric.EntityType]} placement="right" enterDelay={500}><span>{METRIC_LABELS[NodeColorMetric.EntityType]}</span></Tooltip></MenuItem>
+            <MenuItem value={NodeColorMetric.CommunityLouvain}><Tooltip title={METRIC_TOOLTIPS[NodeColorMetric.CommunityLouvain]} placement="right" enterDelay={500}><span>{METRIC_LABELS[NodeColorMetric.CommunityLouvain]}</span></Tooltip></MenuItem>
+            <MenuItem value={NodeColorMetric.CommunityGirvanNewman}><Tooltip title={METRIC_TOOLTIPS[NodeColorMetric.CommunityGirvanNewman]} placement="right" enterDelay={500}><span>{METRIC_LABELS[NodeColorMetric.CommunityGirvanNewman]}</span></Tooltip></MenuItem>
+            <MenuItem value={NodeColorMetric.CommunityLabelPropagation}><Tooltip title={METRIC_TOOLTIPS[NodeColorMetric.CommunityLabelPropagation]} placement="right" enterDelay={500}><span>{METRIC_LABELS[NodeColorMetric.CommunityLabelPropagation]}</span></Tooltip></MenuItem>
+            <MenuItem value={NodeColorMetric.CommunitySpectral}><Tooltip title={METRIC_TOOLTIPS[NodeColorMetric.CommunitySpectral]} placement="right" enterDelay={500}><span>{METRIC_LABELS[NodeColorMetric.CommunitySpectral]}</span></Tooltip></MenuItem>
+            <MenuItem value={NodeColorMetric.LocalClusteringCoefficient}><Tooltip title={METRIC_TOOLTIPS[NodeColorMetric.LocalClusteringCoefficient]} placement="right" enterDelay={500}><span>{METRIC_LABELS[NodeColorMetric.LocalClusteringCoefficient]}</span></Tooltip></MenuItem>
+            <MenuItem value={NodeColorMetric.KCoreNumber}><Tooltip title={METRIC_TOOLTIPS[NodeColorMetric.KCoreNumber]} placement="right" enterDelay={500}><span>{METRIC_LABELS[NodeColorMetric.KCoreNumber]}</span></Tooltip></MenuItem>
             <ListSubheader sx={{ fontSize: '0.72rem', lineHeight: '1.6' }}>
               Focus-relative (select a node first)
             </ListSubheader>
             {NODE_PAIR_METRICS.map((m) => (
               <MenuItem key={m} value={m} disabled={focusEntityId === null}>
-                {METRIC_LABELS[m]}
+                <Tooltip title={METRIC_TOOLTIPS[m]} placement="right" enterDelay={500}>
+                  <span>{METRIC_LABELS[m]}</span>
+                </Tooltip>
               </MenuItem>
             ))}
           </Select>

--- a/frontend/src/components/kg/KGTopBar.tsx
+++ b/frontend/src/components/kg/KGTopBar.tsx
@@ -18,6 +18,7 @@ import {
   Typography,
   Tooltip,
   Slider,
+  ListSubheader,
 } from '@mui/material';
 import {
   ArrowBack,
@@ -34,9 +35,27 @@ import {
   setOccurrenceThreshold,
   setTrimLeaves,
 } from '../../store/graphSlice';
-import { useGraphListQuery, useBooksWithChaptersQuery } from '../../hooks/useKGQueries';
+import {
+  setNodeSizeMetric,
+  setNodeColorMetric,
+  setNodeSizeParams,
+  setNodeColorParams,
+} from '../../store/metricsSlice';
+import {
+  useGraphListQuery,
+  useBooksWithChaptersQuery,
+  useNodeMetricQuery,
+  useNodePairMetricQuery,
+} from '../../hooks/useKGQueries';
 import { kgAPI } from '../../services/kgAPI';
-import { KGGraphMeta, ENTITY_TYPE_COLORS } from '../../types/kg';
+import {
+  KGGraphMeta,
+  ENTITY_TYPE_COLORS,
+  NODE_PAIR_METRICS,
+  NodeSizeMetric,
+  NodeColorMetric,
+  NodePairMetric,
+} from '../../types/kg';
 
 function buildGraphLabel(
   graph: KGGraphMeta,
@@ -61,15 +80,53 @@ function buildGraphLabel(
 
 const KGTopBar: React.FC = () => {
   const dispatch = useAppDispatch();
-  const { graphName, displayMode, hopCount, searchResults, focusHistory, historyIndex, occurrenceThreshold, trimLeaves } =
+  const { graphName, displayMode, hopCount, searchResults, focusHistory, historyIndex, occurrenceThreshold, trimLeaves, focusEntityId } =
     useAppSelector((s) => s.graph);
+  const { nodeSizeMetric, nodeColorMetric, nodeSizeParams, nodeColorParams } =
+    useAppSelector((s) => s.metrics);
 
   const { data: graphList, isLoading: graphsLoading } = useGraphListQuery();
   const { bookTitles, chapterTitles } = useBooksWithChaptersQuery();
 
+  // Size metric query (for loading indicator)
+  const isNodePairColorMetric = NODE_PAIR_METRICS.includes(nodeColorMetric as NodePairMetric);
+  const sizeMetricQuery = useNodeMetricQuery(
+    graphName, nodeSizeMetric, nodeSizeParams,
+    nodeSizeMetric !== 'occurrence_count'
+  );
+  const colorMetricQuery = useNodeMetricQuery(
+    graphName, nodeColorMetric as NodeColorMetric, nodeColorParams,
+    !isNodePairColorMetric && nodeColorMetric !== 'entity_type'
+  );
+  const colorPairMetricQuery = useNodePairMetricQuery(
+    graphName, focusEntityId, nodeColorMetric as NodePairMetric,
+    isNodePairColorMetric && focusEntityId !== null
+  );
+  const sizeLoading = sizeMetricQuery.isFetching || sizeMetricQuery.data?.status === 'computing';
+  const colorLoading = colorMetricQuery.isFetching || colorMetricQuery.data?.status === 'computing'
+    || colorPairMetricQuery.isFetching;
+
+  // Param input local state (committed on enter/blur)
+  const [dampingInput, setDampingInput] = useState(String(nodeSizeParams.damping ?? 0.85));
+  const [kInput, setKInput] = useState(String(nodeColorParams.k ?? 5));
+
   const [searchInput, setSearchInput] = useState('');
   const [searchOpen, setSearchOpen] = useState(false);
   const [searching, setSearching] = useState(false);
+
+  const commitDamping = useCallback(() => {
+    const val = parseFloat(dampingInput);
+    if (!isNaN(val) && val > 0 && val < 1) {
+      dispatch(setNodeSizeParams({ ...nodeSizeParams, damping: val }));
+    }
+  }, [dampingInput, nodeSizeParams, dispatch]);
+
+  const commitK = useCallback(() => {
+    const val = parseInt(kInput, 10);
+    if (!isNaN(val) && val >= 2) {
+      dispatch(setNodeColorParams({ ...nodeColorParams, k: val }));
+    }
+  }, [kInput, nodeColorParams, dispatch]);
 
   const handleSearch = useCallback(
     async (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -221,6 +278,93 @@ const KGTopBar: React.FC = () => {
           ))}
         </Select>
       </FormControl>
+
+      {/* Node size metric selector */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+        <FormControl size="small" sx={{ minWidth: 160 }}>
+          <InputLabel>Size</InputLabel>
+          <Select
+            label="Size"
+            value={nodeSizeMetric}
+            onChange={(e) => dispatch(setNodeSizeMetric(e.target.value as NodeSizeMetric))}
+            endAdornment={
+              sizeLoading ? <CircularProgress size={14} sx={{ mr: 2 }} /> : null
+            }
+          >
+            <MenuItem value="occurrence_count">Occurrence count</MenuItem>
+            <MenuItem value="degree_centrality">Degree centrality</MenuItem>
+            <MenuItem value="betweenness_centrality">Betweenness centrality</MenuItem>
+            <MenuItem value="pagerank">PageRank</MenuItem>
+            <MenuItem value="closeness_centrality">Closeness centrality</MenuItem>
+            <MenuItem value="kcore_number">K-core number</MenuItem>
+          </Select>
+        </FormControl>
+        {nodeSizeMetric === 'pagerank' && (
+          <Tooltip title="Damping factor (0–1)">
+            <TextField
+              size="small"
+              label="Damping"
+              type="number"
+              value={dampingInput}
+              onChange={(e) => setDampingInput(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && commitDamping()}
+              onBlur={commitDamping}
+              inputProps={{ min: 0.01, max: 0.99, step: 0.05 }}
+              sx={{ width: 90 }}
+            />
+          </Tooltip>
+        )}
+      </Box>
+
+      {/* Node color metric selector */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+        <FormControl size="small" sx={{ minWidth: 180 }}>
+          <InputLabel>Color</InputLabel>
+          <Select
+            label="Color"
+            value={nodeColorMetric}
+            onChange={(e) => dispatch(setNodeColorMetric(e.target.value as NodeColorMetric | NodePairMetric))}
+            endAdornment={
+              colorLoading ? <CircularProgress size={14} sx={{ mr: 2 }} /> : null
+            }
+          >
+            <MenuItem value="entity_type">Entity type</MenuItem>
+            <MenuItem value="community_louvain">Community — Louvain</MenuItem>
+            <MenuItem value="community_girvan_newman">Community — Girvan-Newman</MenuItem>
+            <MenuItem value="community_label_propagation">Community — Label prop.</MenuItem>
+            <MenuItem value="community_spectral">Community — Spectral</MenuItem>
+            <MenuItem value="local_clustering_coefficient">Local clustering coeff.</MenuItem>
+            <MenuItem value="kcore_number">K-core number</MenuItem>
+            <ListSubheader sx={{ fontSize: '0.72rem', lineHeight: '1.6' }}>
+              Focus-relative (select a node first)
+            </ListSubheader>
+            {(NODE_PAIR_METRICS as string[]).filter((m) => m !== 'resistance_distance').map((m) => (
+              <MenuItem
+                key={m}
+                value={m}
+                disabled={focusEntityId === null}
+              >
+                {m.replace(/_/g, ' ')}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        {nodeColorMetric === 'community_spectral' && (
+          <Tooltip title="Number of clusters (k ≥ 2)">
+            <TextField
+              size="small"
+              label="k"
+              type="number"
+              value={kInput}
+              onChange={(e) => setKInput(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && commitK()}
+              onBlur={commitK}
+              inputProps={{ min: 2, max: 20, step: 1 }}
+              sx={{ width: 70 }}
+            />
+          </Tooltip>
+        )}
+      </Box>
 
       {/* N-hop toggle */}
       <ToggleButtonGroup

--- a/frontend/src/components/kg/KGTopBar.tsx
+++ b/frontend/src/components/kg/KGTopBar.tsx
@@ -51,6 +51,7 @@ import { kgAPI } from '../../services/kgAPI';
 import {
   KGGraphMeta,
   ENTITY_TYPE_COLORS,
+  METRIC_LABELS,
   NODE_PAIR_METRICS,
   NodeSizeMetric,
   NodeColorMetric,
@@ -328,23 +329,19 @@ const KGTopBar: React.FC = () => {
               colorLoading ? <CircularProgress size={14} sx={{ mr: 2 }} /> : null
             }
           >
-            <MenuItem value={NodeColorMetric.EntityType}>Entity type</MenuItem>
-            <MenuItem value={NodeColorMetric.CommunityLouvain}>Community — Louvain</MenuItem>
-            <MenuItem value={NodeColorMetric.CommunityGirvanNewman}>Community — Girvan-Newman</MenuItem>
-            <MenuItem value={NodeColorMetric.CommunityLabelPropagation}>Community — Label prop.</MenuItem>
-            <MenuItem value={NodeColorMetric.CommunitySpectral}>Community — Spectral</MenuItem>
-            <MenuItem value={NodeColorMetric.LocalClusteringCoefficient}>Local clustering coeff.</MenuItem>
-            <MenuItem value={NodeColorMetric.KCoreNumber}>K-core number</MenuItem>
+            <MenuItem value={NodeColorMetric.EntityType}>{METRIC_LABELS[NodeColorMetric.EntityType]}</MenuItem>
+            <MenuItem value={NodeColorMetric.CommunityLouvain}>{METRIC_LABELS[NodeColorMetric.CommunityLouvain]}</MenuItem>
+            <MenuItem value={NodeColorMetric.CommunityGirvanNewman}>{METRIC_LABELS[NodeColorMetric.CommunityGirvanNewman]}</MenuItem>
+            <MenuItem value={NodeColorMetric.CommunityLabelPropagation}>{METRIC_LABELS[NodeColorMetric.CommunityLabelPropagation]}</MenuItem>
+            <MenuItem value={NodeColorMetric.CommunitySpectral}>{METRIC_LABELS[NodeColorMetric.CommunitySpectral]}</MenuItem>
+            <MenuItem value={NodeColorMetric.LocalClusteringCoefficient}>{METRIC_LABELS[NodeColorMetric.LocalClusteringCoefficient]}</MenuItem>
+            <MenuItem value={NodeColorMetric.KCoreNumber}>{METRIC_LABELS[NodeColorMetric.KCoreNumber]}</MenuItem>
             <ListSubheader sx={{ fontSize: '0.72rem', lineHeight: '1.6' }}>
               Focus-relative (select a node first)
             </ListSubheader>
-            {(NODE_PAIR_METRICS as string[]).map((m) => (
-              <MenuItem
-                key={m}
-                value={m}
-                disabled={focusEntityId === null}
-              >
-                {m.replace(/_/g, ' ')}
+            {NODE_PAIR_METRICS.map((m) => (
+              <MenuItem key={m} value={m} disabled={focusEntityId === null}>
+                {METRIC_LABELS[m]}
               </MenuItem>
             ))}
           </Select>

--- a/frontend/src/components/kg/LegendOverlay.tsx
+++ b/frontend/src/components/kg/LegendOverlay.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+import { interpolateViridis } from 'd3-scale-chromatic';
+import { ENTITY_TYPE_COLORS, ENTITY_TYPES } from '../../types/kg';
+
+// Pre-compute viridis CSS gradient (10 stops, left=t0, right=t1)
+const VIRIDIS_GRADIENT = (() => {
+  const stops = Array.from({ length: 10 }, (_, i) => {
+    const t = i / 9;
+    return `${interpolateViridis(t)} ${(t * 100).toFixed(0)}%`;
+  });
+  return `linear-gradient(to right, ${stops.join(', ')})`;
+})();
+
+function formatVal(v: number): string {
+  if (v === 0) return '0';
+  const abs = Math.abs(v);
+  if (abs >= 100) return v.toFixed(0);
+  if (abs >= 10) return v.toFixed(1);
+  return v.toFixed(2);
+}
+
+interface LegendOverlayProps {
+  /** null = community metric, no legend */
+  mode: 'entity_type' | 'continuous' | null;
+  // Continuous mode only
+  colorNormMin?: number;
+  colorNormMax?: number;
+  label?: string;
+}
+
+const LegendOverlay: React.FC<LegendOverlayProps> = ({
+  mode,
+  colorNormMin = 0,
+  colorNormMax = 1,
+  label,
+}) => {
+  if (mode === null) return null;
+
+  return (
+    <Box
+      sx={{
+        position: 'absolute',
+        bottom: 16,
+        left: 16,
+        zIndex: 10,
+        bgcolor: 'rgba(255,255,255,0.88)',
+        borderRadius: 1,
+        px: 1.5,
+        py: 1,
+        boxShadow: 1,
+        minWidth: 140,
+        maxWidth: 200,
+        pointerEvents: 'none',
+      }}
+    >
+      {mode === 'entity_type' && (
+        <>
+          {ENTITY_TYPES.map((type) => (
+            <Box key={type} sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mb: 0.25 }}>
+              <Box
+                sx={{
+                  width: 11,
+                  height: 11,
+                  borderRadius: '2px',
+                  bgcolor: ENTITY_TYPE_COLORS[type],
+                  flexShrink: 0,
+                }}
+              />
+              <Typography variant="caption" sx={{ textTransform: 'capitalize' }}>
+                {type}
+              </Typography>
+            </Box>
+          ))}
+        </>
+      )}
+
+      {mode === 'continuous' && (
+        <>
+          {label && (
+            <Typography variant="caption" sx={{ display: 'block', mb: 0.75, fontWeight: 500, lineHeight: 1.2 }}>
+              {label}
+            </Typography>
+          )}
+          <Box
+            sx={{
+              height: 10,
+              borderRadius: '2px',
+              background: VIRIDIS_GRADIENT,
+              mb: 0.25,
+            }}
+          />
+          <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+            <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+              {formatVal(colorNormMin)}
+            </Typography>
+            <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+              {formatVal(colorNormMax)}
+            </Typography>
+          </Box>
+        </>
+      )}
+    </Box>
+  );
+};
+
+export default LegendOverlay;

--- a/frontend/src/hooks/useKGQueries.ts
+++ b/frontend/src/hooks/useKGQueries.ts
@@ -1,6 +1,7 @@
 import { useQuery, useQueries } from '@tanstack/react-query';
 import { kgAPI } from '../services/kgAPI';
 import { chatAPI } from '../services/api';
+import { NodeColorMetric, NodePairMetric, NodeSizeMetric } from '../types/kg';
 
 export function useGraphListQuery() {
   return useQuery({
@@ -71,5 +72,46 @@ export function useEntityQuery(entityId: string | null) {
     queryFn: () => kgAPI.getEntity(entityId!),
     enabled: entityId !== null,
     staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useGraphMetricsQuery(graphName: string) {
+  return useQuery({
+    queryKey: ['kg', 'metrics', 'graph', graphName],
+    queryFn: () => kgAPI.getGraphMetrics(graphName),
+    // Poll every 2s while backend is still computing
+    refetchInterval: (query) =>
+      query.state.data?.status === 'computing' ? 2000 : false,
+    staleTime: Infinity, // server caches indefinitely; no need to re-fetch once ready
+  });
+}
+
+export function useNodeMetricQuery(
+  graphName: string,
+  metric: NodeSizeMetric | NodeColorMetric,
+  params: Record<string, number>,
+  enabled: boolean
+) {
+  return useQuery({
+    queryKey: ['kg', 'metrics', 'node', graphName, metric, params],
+    queryFn: () => kgAPI.getNodeMetric(graphName, metric, params),
+    enabled,
+    refetchInterval: (query) =>
+      query.state.data?.status === 'computing' ? 2000 : false,
+    staleTime: Infinity,
+  });
+}
+
+export function useNodePairMetricQuery(
+  graphName: string,
+  focusId: string | null,
+  metric: NodePairMetric,
+  enabled: boolean
+) {
+  return useQuery({
+    queryKey: ['kg', 'metrics', 'node-pair', graphName, focusId, metric],
+    queryFn: () => kgAPI.getNodePairMetric(graphName, focusId!, metric),
+    enabled: enabled && focusId !== null,
+    staleTime: 0, // always fresh when focus changes
   });
 }

--- a/frontend/src/pages/KGPage.tsx
+++ b/frontend/src/pages/KGPage.tsx
@@ -4,8 +4,11 @@ import { useAppSelector } from '../store';
 import {
   useGraphQuery,
   useSubgraphQuery,
+  useGraphMetricsQuery,
+  useNodeMetricQuery,
+  useNodePairMetricQuery,
 } from '../hooks/useKGQueries';
-import { GraphResponse } from '../types/kg';
+import { GraphResponse, NODE_PAIR_METRICS, NodeColorMetric, NodePairMetric } from '../types/kg';
 import KGTopBar from '../components/kg/KGTopBar';
 import ForceGraphPanel from '../components/kg/ForceGraphPanel';
 import EntityPanel from '../components/kg/EntityPanel';
@@ -76,6 +79,7 @@ function applyTrim(graph: GraphResponse, focusEntityId: string | null, threshold
 
 const KGPage: React.FC = () => {
   const { graphName, displayMode, hopCount, focusEntityId, occurrenceThreshold, trimLeaves } = useAppSelector((s) => s.graph);
+  const { nodeSizeMetric, nodeColorMetric, nodeSizeParams, nodeColorParams } = useAppSelector((s) => s.metrics);
 
   const {
     data: fullGraph,
@@ -94,6 +98,57 @@ const KGPage: React.FC = () => {
 
   const activeGraph = displayMode === 'nhop' && focusEntityId ? subgraph : fullGraph;
   const isLoading = displayMode === 'nhop' && focusEntityId ? subgraphLoading : fullGraphLoading;
+
+  // --------------- Metric queries ---------------
+
+  // Graph-level metrics (shown in entity panel unfocused state)
+  const graphMetricsQuery = useGraphMetricsQuery(graphName);
+
+  // Node size metric
+  const sizeMetricQuery = useNodeMetricQuery(
+    graphName, nodeSizeMetric, nodeSizeParams,
+    nodeSizeMetric !== 'occurrence_count'
+  );
+
+  // Node color metric (node-level or node-pair)
+  const isNodePairColorMetric = NODE_PAIR_METRICS.includes(nodeColorMetric as NodePairMetric);
+  const colorMetricQuery = useNodeMetricQuery(
+    graphName, nodeColorMetric as NodeColorMetric, nodeColorParams,
+    !isNodePairColorMetric && nodeColorMetric !== 'entity_type'
+  );
+  const colorPairMetricQuery = useNodePairMetricQuery(
+    graphName, focusEntityId, nodeColorMetric as NodePairMetric,
+    isNodePairColorMetric && focusEntityId !== null
+  );
+
+  // Resolved metric values to pass to ForceGraphPanel
+  const sizeMetricData = sizeMetricQuery.data;
+  const sizeReady = sizeMetricData?.status === 'ready' && !('num_communities' in (sizeMetricData ?? {}));
+  const sizeValues = sizeReady ? sizeMetricData!.values : undefined;
+  const sizeNormMin = sizeReady ? (sizeMetricData as { norm_min: number }).norm_min : 0;
+  const sizeNormMax = sizeReady ? (sizeMetricData as { norm_max: number }).norm_max : 1;
+
+  // Determine active color metric data
+  const activeColorData = isNodePairColorMetric
+    ? colorPairMetricQuery.data
+    : colorMetricQuery.data?.status === 'ready' ? colorMetricQuery.data : undefined;
+
+  // Community metrics have a 'num_communities' field; continuous ones have 'norm_min'/'norm_max'
+  const isCommunityMetric = activeColorData != null && 'num_communities' in activeColorData;
+  const communityValues = isCommunityMetric
+    ? (activeColorData as { values: Record<string, number> }).values
+    : undefined;
+  const colorMetricValues = !isCommunityMetric && activeColorData != null
+    ? (activeColorData as { values: Record<string, number> }).values
+    : undefined;
+  const colorNormMin = !isCommunityMetric && activeColorData != null
+    ? (activeColorData as { norm_min: number }).norm_min
+    : 0;
+  const colorNormMax = !isCommunityMetric && activeColorData != null
+    ? (activeColorData as { norm_max: number }).norm_max
+    : 1;
+
+  // --------------- Display graph ---------------
 
   const displayGraph = useMemo(() => {
     if (!activeGraph) return activeGraph;
@@ -114,10 +169,24 @@ const KGPage: React.FC = () => {
     <Box sx={{ display: 'flex', flexDirection: 'column', height: 'calc(100vh - 64px)' }}>
       <KGTopBar />
       <Box sx={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
-        <ForceGraphPanel graphData={displayGraph} isLoading={isLoading} />
+        <ForceGraphPanel
+          graphData={displayGraph}
+          isLoading={isLoading}
+          sizeMetricValues={sizeValues}
+          sizeNormMin={sizeNormMin}
+          sizeNormMax={sizeNormMax}
+          colorMetricValues={colorMetricValues}
+          colorNormMin={colorNormMin}
+          colorNormMax={colorNormMax}
+          communityValues={communityValues}
+        />
         <Divider orientation="vertical" flexItem />
         <Box sx={{ width: 340, flexShrink: 0, overflow: 'hidden', borderLeft: 0 }}>
-          <EntityPanel activeGraph={activeGraph} />
+          <EntityPanel
+            activeGraph={activeGraph}
+            graphMetrics={graphMetricsQuery.data}
+            graphMetricsLoading={graphMetricsQuery.isLoading || graphMetricsQuery.isFetching}
+          />
         </Box>
       </Box>
     </Box>

--- a/frontend/src/pages/KGPage.tsx
+++ b/frontend/src/pages/KGPage.tsx
@@ -8,7 +8,7 @@ import {
   useNodeMetricQuery,
   useNodePairMetricQuery,
 } from '../hooks/useKGQueries';
-import { GraphResponse, NODE_PAIR_METRICS, NodeColorMetric, NodePairMetric } from '../types/kg';
+import { DISTANCE_METRICS, GraphResponse, NODE_PAIR_METRICS, NodeColorMetric, NodePairMetric, NodeSizeMetric } from '../types/kg';
 import KGTopBar from '../components/kg/KGTopBar';
 import ForceGraphPanel from '../components/kg/ForceGraphPanel';
 import EntityPanel from '../components/kg/EntityPanel';
@@ -59,6 +59,20 @@ function trimLeavesRecursive(
   };
 }
 
+// Compute min/max norm bounds from only the currently displayed nodes.
+// Excludes sentinel -1 values (unreachable nodes in node-pair metrics).
+function computeDisplayNorms(
+  values: Record<string, number> | undefined,
+  nodeIds: Set<string>
+): [number, number] {
+  if (!values || nodeIds.size === 0) return [0, 1];
+  const displayed = Array.from(nodeIds)
+    .map((id) => values[id])
+    .filter((v): v is number => v !== undefined && v >= 0);
+  if (displayed.length === 0) return [0, 1];
+  return [Math.min(...displayed), Math.max(...displayed)];
+}
+
 function applyTrim(graph: GraphResponse, focusEntityId: string | null, threshold: number): GraphResponse {
   const keepIds = new Set(
     graph.nodes
@@ -107,26 +121,24 @@ const KGPage: React.FC = () => {
   // Node size metric
   const sizeMetricQuery = useNodeMetricQuery(
     graphName, nodeSizeMetric, nodeSizeParams,
-    nodeSizeMetric !== 'occurrence_count'
+    nodeSizeMetric !== NodeSizeMetric.OccurrenceCount
   );
 
   // Node color metric (node-level or node-pair)
   const isNodePairColorMetric = NODE_PAIR_METRICS.includes(nodeColorMetric as NodePairMetric);
   const colorMetricQuery = useNodeMetricQuery(
     graphName, nodeColorMetric as NodeColorMetric, nodeColorParams,
-    !isNodePairColorMetric && nodeColorMetric !== 'entity_type'
+    !isNodePairColorMetric && nodeColorMetric !== NodeColorMetric.EntityType
   );
   const colorPairMetricQuery = useNodePairMetricQuery(
     graphName, focusEntityId, nodeColorMetric as NodePairMetric,
     isNodePairColorMetric && focusEntityId !== null
   );
 
-  // Resolved metric values to pass to ForceGraphPanel
+  // Resolved metric values (full graph — norms are recomputed per displayed nodes below)
   const sizeMetricData = sizeMetricQuery.data;
   const sizeReady = sizeMetricData?.status === 'ready' && !('num_communities' in (sizeMetricData ?? {}));
   const sizeValues = sizeReady ? sizeMetricData!.values : undefined;
-  const sizeNormMin = sizeReady ? (sizeMetricData as { norm_min: number }).norm_min : 0;
-  const sizeNormMax = sizeReady ? (sizeMetricData as { norm_max: number }).norm_max : 1;
 
   // Determine active color metric data
   const activeColorData = isNodePairColorMetric
@@ -141,12 +153,6 @@ const KGPage: React.FC = () => {
   const colorMetricValues = !isCommunityMetric && activeColorData != null
     ? (activeColorData as { values: Record<string, number> }).values
     : undefined;
-  const colorNormMin = !isCommunityMetric && activeColorData != null
-    ? (activeColorData as { norm_min: number }).norm_min
-    : 0;
-  const colorNormMax = !isCommunityMetric && activeColorData != null
-    ? (activeColorData as { norm_max: number }).norm_max
-    : 1;
 
   // --------------- Display graph ---------------
 
@@ -164,6 +170,23 @@ const KGPage: React.FC = () => {
     );
     return { ...afterThreshold, nodes, links, node_count: nodes.length, edge_count: links.length };
   }, [activeGraph, occurrenceThreshold, trimLeaves, focusEntityId]);
+
+  // Norm bounds recomputed from displayed nodes so trimmed nodes don't skew the color/size scale
+  const displayNodeIds = useMemo(
+    () => new Set((displayGraph?.nodes ?? []).map((n) => n.id)),
+    [displayGraph]
+  );
+  const [sizeNormMin, sizeNormMax] = useMemo(
+    () => computeDisplayNorms(sizeValues, displayNodeIds),
+    [sizeValues, displayNodeIds]
+  );
+  const [colorNormMinRaw, colorNormMaxRaw] = useMemo(
+    () => computeDisplayNorms(colorMetricValues, displayNodeIds),
+    [colorMetricValues, displayNodeIds]
+  );
+  const invertColorScale = DISTANCE_METRICS.has(nodeColorMetric);
+  const colorNormMin = invertColorScale ? colorNormMaxRaw : colorNormMinRaw;
+  const colorNormMax = invertColorScale ? colorNormMinRaw : colorNormMaxRaw;
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: 'calc(100vh - 64px)' }}>

--- a/frontend/src/pages/KGPage.tsx
+++ b/frontend/src/pages/KGPage.tsx
@@ -8,7 +8,7 @@ import {
   useNodeMetricQuery,
   useNodePairMetricQuery,
 } from '../hooks/useKGQueries';
-import { DISTANCE_METRICS, GraphResponse, NODE_PAIR_METRICS, NodeColorMetric, NodePairMetric, NodeSizeMetric } from '../types/kg';
+import { DISTANCE_METRICS, GraphResponse, METRIC_LABELS, NODE_PAIR_METRICS, NodeColorMetric, NodePairMetric, NodeSizeMetric } from '../types/kg';
 import KGTopBar from '../components/kg/KGTopBar';
 import ForceGraphPanel from '../components/kg/ForceGraphPanel';
 import EntityPanel from '../components/kg/EntityPanel';
@@ -202,6 +202,7 @@ const KGPage: React.FC = () => {
           colorNormMin={colorNormMin}
           colorNormMax={colorNormMax}
           communityValues={communityValues}
+          colorMetricLabel={METRIC_LABELS[nodeColorMetric as NodeColorMetric | NodePairMetric]}
         />
         <Divider orientation="vertical" flexItem />
         <Box sx={{ width: 340, flexShrink: 0, overflow: 'hidden', borderLeft: 0 }}>

--- a/frontend/src/services/kgAPI.ts
+++ b/frontend/src/services/kgAPI.ts
@@ -1,8 +1,12 @@
 import axios, { AxiosInstance } from 'axios';
 import {
-  GraphListResponse,
-  GraphResponse,
+  CommunityMetricResponse,
   EntityDetail,
+  GraphListResponse,
+  GraphMetricsResponse,
+  GraphResponse,
+  NodeMetricResponse,
+  NodePairMetricResponse,
   SearchRequest,
   SearchResponse,
 } from '../types/kg';
@@ -47,6 +51,41 @@ class KGAPI {
 
   async search(request: SearchRequest): Promise<SearchResponse> {
     const response = await this.api.post<SearchResponse>('/api/kg/search', request);
+    return response.data;
+  }
+
+  async getGraphMetrics(graphName: string): Promise<GraphMetricsResponse> {
+    const response = await this.api.get<GraphMetricsResponse>('/api/kg/metrics/graph', {
+      params: { graph_name: graphName },
+      validateStatus: (s) => s === 200 || s === 202,
+    });
+    return response.data;
+  }
+
+  async getNodeMetric(
+    graphName: string,
+    metric: string,
+    params: Record<string, number>
+  ): Promise<NodeMetricResponse | CommunityMetricResponse> {
+    const response = await this.api.get<NodeMetricResponse | CommunityMetricResponse>(
+      '/api/kg/metrics/node',
+      {
+        params: { graph_name: graphName, metric, ...params },
+        validateStatus: (s) => s === 200 || s === 202,
+      }
+    );
+    return response.data;
+  }
+
+  async getNodePairMetric(
+    graphName: string,
+    focusId: string,
+    metric: string
+  ): Promise<NodePairMetricResponse> {
+    const response = await this.api.get<NodePairMetricResponse>(
+      '/api/kg/metrics/node-pair',
+      { params: { graph_name: graphName, focus_entity_id: focusId, metric } }
+    );
     return response.data;
   }
 }

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,10 +1,12 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 import graphReducer from './graphSlice';
+import metricsReducer from './metricsSlice';
 
 export const store = configureStore({
   reducer: {
     graph: graphReducer,
+    metrics: metricsReducer,
   },
 });
 

--- a/frontend/src/store/metricsSlice.ts
+++ b/frontend/src/store/metricsSlice.ts
@@ -9,8 +9,8 @@ interface MetricsState {
 }
 
 const initialState: MetricsState = {
-  nodeSizeMetric: 'occurrence_count',
-  nodeColorMetric: 'entity_type',
+  nodeSizeMetric: NodeSizeMetric.OccurrenceCount,
+  nodeColorMetric: NodeColorMetric.EntityType,
   nodeSizeParams: { damping: 0.85 },
   nodeColorParams: { k: 5 },
 };

--- a/frontend/src/store/metricsSlice.ts
+++ b/frontend/src/store/metricsSlice.ts
@@ -1,0 +1,44 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { NodeColorMetric, NodePairMetric, NodeSizeMetric } from '../types/kg';
+
+interface MetricsState {
+  nodeSizeMetric: NodeSizeMetric;
+  nodeColorMetric: NodeColorMetric | NodePairMetric;
+  nodeSizeParams: Record<string, number>; // e.g. { damping: 0.85 }
+  nodeColorParams: Record<string, number>; // e.g. { k: 5 }
+}
+
+const initialState: MetricsState = {
+  nodeSizeMetric: 'occurrence_count',
+  nodeColorMetric: 'entity_type',
+  nodeSizeParams: { damping: 0.85 },
+  nodeColorParams: { k: 5 },
+};
+
+const metricsSlice = createSlice({
+  name: 'metrics',
+  initialState,
+  reducers: {
+    setNodeSizeMetric(state, action: PayloadAction<NodeSizeMetric>) {
+      state.nodeSizeMetric = action.payload;
+    },
+    setNodeColorMetric(state, action: PayloadAction<NodeColorMetric | NodePairMetric>) {
+      state.nodeColorMetric = action.payload;
+    },
+    setNodeSizeParams(state, action: PayloadAction<Record<string, number>>) {
+      state.nodeSizeParams = action.payload;
+    },
+    setNodeColorParams(state, action: PayloadAction<Record<string, number>>) {
+      state.nodeColorParams = action.payload;
+    },
+  },
+});
+
+export const {
+  setNodeSizeMetric,
+  setNodeColorMetric,
+  setNodeSizeParams,
+  setNodeColorParams,
+} = metricsSlice.actions;
+
+export default metricsSlice.reducer;

--- a/frontend/src/types/kg.ts
+++ b/frontend/src/types/kg.ts
@@ -92,3 +92,87 @@ export const ENTITY_TYPE_COLORS: Record<string, string> = {
   event: '#e15759',
   concept: '#b07aa1',
 };
+
+// ---------------------------------------------------------------------------
+// Metric enums (mirror backend NodeSizeMetric / NodeColorMetric / NodePairMetric)
+// ---------------------------------------------------------------------------
+
+export type NodeSizeMetric =
+  | 'occurrence_count'
+  | 'degree_centrality'
+  | 'betweenness_centrality'
+  | 'pagerank'
+  | 'closeness_centrality'
+  | 'kcore_number';
+
+export type NodeColorMetric =
+  | 'entity_type'
+  | 'community_louvain'
+  | 'community_girvan_newman'
+  | 'community_label_propagation'
+  | 'community_spectral'
+  | 'local_clustering_coefficient'
+  | 'kcore_number';
+
+export type NodePairMetric =
+  | 'cosine_similarity'
+  | 'jaccard_similarity'
+  | 'adamic_adar'
+  | 'common_neighbor_count'
+  | 'shortest_path_length'
+  | 'resistance_distance';
+
+export const NODE_PAIR_METRICS: NodePairMetric[] = [
+  'cosine_similarity',
+  'jaccard_similarity',
+  'adamic_adar',
+  'common_neighbor_count',
+  'shortest_path_length',
+  'resistance_distance',
+];
+
+// ---------------------------------------------------------------------------
+// Metric response types (mirror backend Pydantic models)
+// ---------------------------------------------------------------------------
+
+export interface GraphMetricsResponse {
+  graph_name: string;
+  density: number;
+  giant_component_ratio: number;
+  num_connected_components: number;
+  avg_shortest_path_length: number | null;
+  diameter: number | null;
+  global_clustering_coefficient: number;
+  num_communities: number;
+  articulation_point_count: number;
+  status: 'ready' | 'computing';
+}
+
+export interface NodeMetricResponse {
+  graph_name: string;
+  metric: string;
+  params: Record<string, number>;
+  values: Record<string, number>; // entity UUID → metric value
+  norm_min: number;
+  norm_max: number;
+  status: 'ready' | 'computing';
+}
+
+export interface CommunityMetricResponse {
+  graph_name: string;
+  metric: string;
+  params: Record<string, number>;
+  values: Record<string, number>; // entity UUID → community ID (int stored as number)
+  num_communities: number;
+  status: 'ready' | 'computing';
+}
+
+export interface NodePairMetricResponse {
+  graph_name: string;
+  focus_entity_id: string;
+  metric: string;
+  params: Record<string, number>;
+  values: Record<string, number>; // entity UUID → value relative to focus
+  norm_min: number;
+  norm_max: number;
+}

--- a/frontend/src/types/kg.ts
+++ b/frontend/src/types/kg.ts
@@ -144,6 +144,30 @@ export const METRIC_LABELS: Record<NodeColorMetric | NodePairMetric, string> = {
   [NodePairMetric.ResistanceDistance]: 'Resistance distance',
 };
 
+// One-sentence descriptions shown as dropdown tooltips
+// NodeSizeMetric.KCoreNumber and NodeColorMetric.KCoreNumber share the same string value,
+// so only one entry is needed.
+export const METRIC_TOOLTIPS: Record<string, string> = {
+  [NodeSizeMetric.OccurrenceCount]: 'Number of times this entity is mentioned across the source text.',
+  [NodeSizeMetric.DegreeCentrality]: 'Fraction of all entities this one is directly connected to.',
+  [NodeSizeMetric.BetweennessCentrality]: 'How often this entity falls on the shortest path between other pairs; highlights bridges and brokers.',
+  [NodeSizeMetric.PageRank]: 'Recursive importance score: high when connected to other high-scoring entities.',
+  [NodeSizeMetric.ClosenessCentrality]: 'How quickly this entity can reach every other entity via the shortest paths.',
+  [NodeSizeMetric.KCoreNumber]: 'Largest cohesive subgraph this entity belongs to, where every member has at least k connections.',
+  [NodeColorMetric.EntityType]: 'Colors nodes by entity category (person, polity, place, event, concept).',
+  [NodeColorMetric.CommunityLouvain]: 'Partitions the graph by greedily maximizing modularity.',
+  [NodeColorMetric.CommunityGirvanNewman]: 'Partitions by iteratively removing the edge with highest betweenness.',
+  [NodeColorMetric.CommunityLabelPropagation]: 'Partitions by iteratively adopting the most common community label among neighbors.',
+  [NodeColorMetric.CommunitySpectral]: 'Partitions into k clusters using spectral decomposition of the graph Laplacian.',
+  [NodeColorMetric.LocalClusteringCoefficient]: "Fraction of this entity's neighbors that are also connected to each other; high for tightly-knit clusters.",
+  [NodePairMetric.CosineSimilarity]: 'Similarity of learned embedding vectors between this entity and the focus node.',
+  [NodePairMetric.JaccardSimilarity]: 'Shared neighbors as a fraction of all combined neighbors with the focus node.',
+  [NodePairMetric.AdamicAdar]: 'Shared-neighbor score weighted by inverse log degree; down-weights hub nodes.',
+  [NodePairMetric.CommonNeighborCount]: 'Number of entities directly connected to both this node and the focus.',
+  [NodePairMetric.ShortestPathLength]: 'Minimum number of edges between this entity and the focus in the undirected graph.',
+  [NodePairMetric.ResistanceDistance]: 'Effective electrical resistance to the focus; lower means more and shorter connection paths.',
+};
+
 // Metrics where lower value = closer to focus — color scale is inverted so
 // close nodes appear bright and distant nodes appear dark.
 export const DISTANCE_METRICS = new Set<string>([

--- a/frontend/src/types/kg.ts
+++ b/frontend/src/types/kg.ts
@@ -127,6 +127,23 @@ export enum NodePairMetric {
 
 export const NODE_PAIR_METRICS: NodePairMetric[] = Object.values(NodePairMetric);
 
+// Human-readable labels for color metric selector and legend
+export const METRIC_LABELS: Record<NodeColorMetric | NodePairMetric, string> = {
+  [NodeColorMetric.EntityType]: 'Entity type',
+  [NodeColorMetric.CommunityLouvain]: 'Community — Louvain',
+  [NodeColorMetric.CommunityGirvanNewman]: 'Community — Girvan-Newman',
+  [NodeColorMetric.CommunityLabelPropagation]: 'Community — Label prop.',
+  [NodeColorMetric.CommunitySpectral]: 'Community — Spectral',
+  [NodeColorMetric.LocalClusteringCoefficient]: 'Local clustering coeff.',
+  [NodeColorMetric.KCoreNumber]: 'K-core number',
+  [NodePairMetric.CosineSimilarity]: 'Cosine similarity',
+  [NodePairMetric.JaccardSimilarity]: 'Jaccard similarity',
+  [NodePairMetric.AdamicAdar]: 'Adamic-Adar',
+  [NodePairMetric.CommonNeighborCount]: 'Common neighbors',
+  [NodePairMetric.ShortestPathLength]: 'Shortest path length',
+  [NodePairMetric.ResistanceDistance]: 'Resistance distance',
+};
+
 // Metrics where lower value = closer to focus — color scale is inverted so
 // close nodes appear bright and distant nodes appear dark.
 export const DISTANCE_METRICS = new Set<string>([

--- a/frontend/src/types/kg.ts
+++ b/frontend/src/types/kg.ts
@@ -97,39 +97,42 @@ export const ENTITY_TYPE_COLORS: Record<string, string> = {
 // Metric enums (mirror backend NodeSizeMetric / NodeColorMetric / NodePairMetric)
 // ---------------------------------------------------------------------------
 
-export type NodeSizeMetric =
-  | 'occurrence_count'
-  | 'degree_centrality'
-  | 'betweenness_centrality'
-  | 'pagerank'
-  | 'closeness_centrality'
-  | 'kcore_number';
+export enum NodeSizeMetric {
+  OccurrenceCount = 'occurrence_count',
+  DegreeCentrality = 'degree_centrality',
+  BetweennessCentrality = 'betweenness_centrality',
+  PageRank = 'pagerank',
+  ClosenessCentrality = 'closeness_centrality',
+  KCoreNumber = 'kcore_number',
+}
 
-export type NodeColorMetric =
-  | 'entity_type'
-  | 'community_louvain'
-  | 'community_girvan_newman'
-  | 'community_label_propagation'
-  | 'community_spectral'
-  | 'local_clustering_coefficient'
-  | 'kcore_number';
+export enum NodeColorMetric {
+  EntityType = 'entity_type',
+  CommunityLouvain = 'community_louvain',
+  CommunityGirvanNewman = 'community_girvan_newman',
+  CommunityLabelPropagation = 'community_label_propagation',
+  CommunitySpectral = 'community_spectral',
+  LocalClusteringCoefficient = 'local_clustering_coefficient',
+  KCoreNumber = 'kcore_number',
+}
 
-export type NodePairMetric =
-  | 'cosine_similarity'
-  | 'jaccard_similarity'
-  | 'adamic_adar'
-  | 'common_neighbor_count'
-  | 'shortest_path_length'
-  | 'resistance_distance';
+export enum NodePairMetric {
+  CosineSimilarity = 'cosine_similarity',
+  JaccardSimilarity = 'jaccard_similarity',
+  AdamicAdar = 'adamic_adar',
+  CommonNeighborCount = 'common_neighbor_count',
+  ShortestPathLength = 'shortest_path_length',
+  ResistanceDistance = 'resistance_distance',
+}
 
-export const NODE_PAIR_METRICS: NodePairMetric[] = [
-  'cosine_similarity',
-  'jaccard_similarity',
-  'adamic_adar',
-  'common_neighbor_count',
-  'shortest_path_length',
-  'resistance_distance',
-];
+export const NODE_PAIR_METRICS: NodePairMetric[] = Object.values(NodePairMetric);
+
+// Metrics where lower value = closer to focus — color scale is inverted so
+// close nodes appear bright and distant nodes appear dark.
+export const DISTANCE_METRICS = new Set<string>([
+  NodePairMetric.ResistanceDistance,
+  NodePairMetric.ShortestPathLength,
+]);
 
 // ---------------------------------------------------------------------------
 // Metric response types (mirror backend Pydantic models)

--- a/src/history_book/api/main.py
+++ b/src/history_book/api/main.py
@@ -3,7 +3,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from .routes import agent, books, chat, kg
+from .routes import agent, books, chat, kg, kg_metrics
 
 
 def create_app() -> FastAPI:
@@ -28,6 +28,7 @@ def create_app() -> FastAPI:
     app.include_router(agent.router, prefix="/api")
     app.include_router(books.router, prefix="/api")
     app.include_router(kg.router, prefix="/api")
+    app.include_router(kg_metrics.router, prefix="/api")
 
     return app
 

--- a/src/history_book/api/models/kg_models.py
+++ b/src/history_book/api/models/kg_models.py
@@ -1,5 +1,6 @@
 """Pydantic models for the Knowledge Graph API."""
 
+from enum import Enum
 from typing import Literal
 
 from pydantic import BaseModel
@@ -80,3 +81,83 @@ class KGGraphMeta(BaseModel):
 
 class GraphListResponse(BaseModel):
     graphs: list[KGGraphMeta]
+
+
+# ---------------------------------------------------------------------------
+# Metric enums
+# ---------------------------------------------------------------------------
+
+
+class NodeSizeMetric(str, Enum):
+    OCCURRENCE_COUNT = "occurrence_count"
+    DEGREE_CENTRALITY = "degree_centrality"
+    BETWEENNESS_CENTRALITY = "betweenness_centrality"
+    PAGERANK = "pagerank"  # params: damping (default 0.85)
+    CLOSENESS_CENTRALITY = "closeness_centrality"
+    KCORE_NUMBER = "kcore_number"
+
+
+class NodeColorMetric(str, Enum):
+    ENTITY_TYPE = "entity_type"
+    COMMUNITY_LOUVAIN = "community_louvain"
+    COMMUNITY_GIRVAN_NEWMAN = "community_girvan_newman"
+    COMMUNITY_LABEL_PROPAGATION = "community_label_propagation"
+    COMMUNITY_SPECTRAL = "community_spectral"  # params: k (default 5)
+    LOCAL_CLUSTERING_COEFFICIENT = "local_clustering_coefficient"
+    KCORE_NUMBER = "kcore_number"
+
+
+class NodePairMetric(str, Enum):
+    COSINE_SIMILARITY = "cosine_similarity"
+    JACCARD_SIMILARITY = "jaccard_similarity"
+    ADAMIC_ADAR = "adamic_adar"
+    COMMON_NEIGHBOR_COUNT = "common_neighbor_count"
+    SHORTEST_PATH_LENGTH = "shortest_path_length"
+    RESISTANCE_DISTANCE = "resistance_distance"  # 501 Not Implemented
+
+
+# ---------------------------------------------------------------------------
+# Metric response models
+# ---------------------------------------------------------------------------
+
+
+class GraphMetricsResponse(BaseModel):
+    graph_name: str
+    density: float
+    giant_component_ratio: float
+    num_connected_components: int
+    avg_shortest_path_length: float | None  # None if main component > 500 nodes
+    diameter: int | None  # None if main component > 500 nodes
+    global_clustering_coefficient: float
+    num_communities: int  # from Louvain
+    articulation_point_count: int
+    status: Literal["ready", "computing"]
+
+
+class NodeMetricResponse(BaseModel):
+    graph_name: str
+    metric: str
+    params: dict[str, float] = {}
+    values: dict[str, float]  # entity UUID → metric value
+    norm_min: float
+    norm_max: float
+    status: Literal["ready", "computing"]
+
+
+class CommunityMetricResponse(BaseModel):
+    graph_name: str
+    metric: str
+    params: dict[str, float] = {}
+    values: dict[str, int]  # entity UUID → community ID (int)
+    num_communities: int
+    status: Literal["ready", "computing"]
+
+
+class NodePairMetricResponse(BaseModel):
+    graph_name: str
+    focus_entity_id: str
+    metric: str
+    params: dict[str, float] = {}
+    values: dict[str, float]  # entity UUID → value relative to focus
+    norm_min: float
+    norm_max: float

--- a/src/history_book/api/routes/dependencies.py
+++ b/src/history_book/api/routes/dependencies.py
@@ -1,0 +1,18 @@
+"""Shared FastAPI dependency factories for KG routes."""
+
+from functools import lru_cache
+
+from history_book.services.kg_metrics_service import KGMetricsService
+from history_book.services.kg_service import KGService
+
+
+@lru_cache
+def get_kg_service() -> KGService:
+    """Get a cached KGService instance (shared across kg and kg_metrics routes)."""
+    return KGService()
+
+
+@lru_cache
+def get_kg_metrics_service() -> KGMetricsService:
+    """Get a cached KGMetricsService instance sharing the same KGService."""
+    return KGMetricsService(get_kg_service())

--- a/src/history_book/api/routes/kg.py
+++ b/src/history_book/api/routes/kg.py
@@ -13,6 +13,7 @@ from history_book.api.models.kg_models import (
     SearchResponse,
 )
 from history_book.api.routes.dependencies import get_kg_metrics_service, get_kg_service
+from history_book.services.kg_metrics_service import KGMetricsService
 from history_book.services.kg_service import KGService
 
 logger = logging.getLogger(__name__)
@@ -51,6 +52,7 @@ async def get_graph(
     graph_name: str,
     background_tasks: BackgroundTasks,
     service: KGService = Depends(get_kg_service),
+    metrics_service: KGMetricsService = Depends(get_kg_metrics_service),
 ):
     """Get all nodes and links for a named graph.
 
@@ -59,7 +61,6 @@ async def get_graph(
     """
     try:
         result = service.get_graph(graph_name)
-        metrics_service = get_kg_metrics_service()
         background_tasks.add_task(metrics_service.trigger_graph_metrics, graph_name)
         return result
     except Exception as e:

--- a/src/history_book/api/routes/kg.py
+++ b/src/history_book/api/routes/kg.py
@@ -1,9 +1,8 @@
 """Knowledge Graph API routes."""
 
 import logging
-from functools import lru_cache
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 
 from history_book.api.models.kg_models import (
     EntityDetail,
@@ -13,17 +12,12 @@ from history_book.api.models.kg_models import (
     SearchRequest,
     SearchResponse,
 )
+from history_book.api.routes.dependencies import get_kg_metrics_service, get_kg_service
 from history_book.services.kg_service import KGService
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/kg", tags=["kg"])
-
-
-@lru_cache
-def get_kg_service() -> KGService:
-    """Get a cached KGService instance."""
-    return KGService()
 
 
 @router.get("/graphs", response_model=GraphListResponse)
@@ -55,11 +49,19 @@ async def list_graphs(
 @router.get("/graphs/{graph_name}", response_model=GraphResponse)
 async def get_graph(
     graph_name: str,
+    background_tasks: BackgroundTasks,
     service: KGService = Depends(get_kg_service),
 ):
-    """Get all nodes and links for a named graph."""
+    """Get all nodes and links for a named graph.
+
+    As a side effect, triggers background computation of graph-level metrics
+    so they are ready by the time the frontend requests them.
+    """
     try:
-        return service.get_graph(graph_name)
+        result = service.get_graph(graph_name)
+        metrics_service = get_kg_metrics_service()
+        background_tasks.add_task(metrics_service.trigger_graph_metrics, graph_name)
+        return result
     except Exception as e:
         logger.error("Failed to get graph %s: %s", graph_name, e)
         raise HTTPException(status_code=500, detail="Failed to retrieve graph") from e

--- a/src/history_book/api/routes/kg_metrics.py
+++ b/src/history_book/api/routes/kg_metrics.py
@@ -32,7 +32,9 @@ async def get_graph_metrics(
         return JSONResponse(content=result.model_dump(), status_code=status_code)
     except Exception as e:
         logger.error("Failed to get graph metrics for %s: %s", graph_name, e)
-        raise HTTPException(status_code=500, detail="Failed to compute graph metrics") from e
+        raise HTTPException(
+            status_code=500, detail="Failed to compute graph metrics"
+        ) from e
 
 
 @router.get("/node")
@@ -67,7 +69,9 @@ async def get_node_metric(
         raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
         logger.error("Failed to get node metric %s for %s: %s", metric, graph_name, e)
-        raise HTTPException(status_code=500, detail="Failed to compute node metric") from e
+        raise HTTPException(
+            status_code=500, detail="Failed to compute node metric"
+        ) from e
 
 
 @router.get("/node-pair", response_model=NodePairMetricResponse)
@@ -102,5 +106,6 @@ async def get_node_pair_metric(
             graph_name,
             e,
         )
-        raise HTTPException(status_code=500, detail="Failed to compute node-pair metric") from e
-
+        raise HTTPException(
+            status_code=500, detail="Failed to compute node-pair metric"
+        ) from e

--- a/src/history_book/api/routes/kg_metrics.py
+++ b/src/history_book/api/routes/kg_metrics.py
@@ -1,0 +1,106 @@
+"""Knowledge Graph metrics API routes."""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import JSONResponse
+
+from history_book.api.models.kg_models import (
+    GraphMetricsResponse,
+    NodePairMetricResponse,
+)
+from history_book.api.routes.dependencies import get_kg_metrics_service
+from history_book.services.kg_metrics_service import KGMetricsService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/kg/metrics", tags=["kg-metrics"])
+
+
+@router.get("/graph", response_model=GraphMetricsResponse)
+async def get_graph_metrics(
+    graph_name: str,
+    service: KGMetricsService = Depends(get_kg_metrics_service),
+) -> JSONResponse:
+    """Get graph-level network metrics.
+
+    Returns 200 with data when ready, 202 while still computing.
+    The first call for a given graph_name triggers background computation.
+    """
+    try:
+        result, status_code = await service.get_graph_metrics(graph_name)
+        return JSONResponse(content=result.model_dump(), status_code=status_code)
+    except Exception as e:
+        logger.error("Failed to get graph metrics for %s: %s", graph_name, e)
+        raise HTTPException(status_code=500, detail="Failed to compute graph metrics") from e
+
+
+@router.get("/node")
+async def get_node_metric(
+    graph_name: str,
+    metric: str,
+    damping: float = 0.85,
+    k: int = 5,
+    service: KGMetricsService = Depends(get_kg_metrics_service),
+) -> JSONResponse:
+    """Get node-level metric values for all nodes in a graph.
+
+    Returns NodeMetricResponse for continuous metrics (degree_centrality,
+    betweenness_centrality, pagerank, closeness_centrality, kcore_number,
+    local_clustering_coefficient) and CommunityMetricResponse for community
+    metrics (community_louvain, community_girvan_newman,
+    community_label_propagation, community_spectral).
+
+    Returns 200 with data when ready, 202 while still computing.
+    Params: damping (PageRank only), k (community_spectral only).
+    """
+    params: dict[str, float] = {}
+    if metric == "pagerank":
+        params["damping"] = damping
+    elif metric == "community_spectral":
+        params["k"] = float(k)
+
+    try:
+        result, status_code = await service.get_node_metric(graph_name, metric, params)
+        return JSONResponse(content=result.model_dump(), status_code=status_code)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        logger.error("Failed to get node metric %s for %s: %s", metric, graph_name, e)
+        raise HTTPException(status_code=500, detail="Failed to compute node metric") from e
+
+
+@router.get("/node-pair", response_model=NodePairMetricResponse)
+async def get_node_pair_metric(
+    graph_name: str,
+    focus_entity_id: str,
+    metric: str,
+    service: KGMetricsService = Depends(get_kg_metrics_service),
+) -> NodePairMetricResponse:
+    """Get node-pair metric values relative to a focus entity (always 200).
+
+    Supported metrics: cosine_similarity, jaccard_similarity, adamic_adar,
+    common_neighbor_count, shortest_path_length.
+    resistance_distance returns 501.
+    """
+    if metric == "resistance_distance":
+        raise HTTPException(
+            status_code=501,
+            detail="Resistance distance is not implemented (computationally infeasible on large graphs)",
+        )
+    try:
+        return service.get_node_pair_metric(graph_name, focus_entity_id, metric, {})
+    except NotImplementedError as e:
+        raise HTTPException(status_code=501, detail=str(e)) from e
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        logger.error(
+            "Failed to get node-pair metric %s for focus %s in %s: %s",
+            metric,
+            focus_entity_id,
+            graph_name,
+            e,
+        )
+        raise HTTPException(status_code=500, detail="Failed to compute node-pair metric") from e
+

--- a/src/history_book/api/routes/kg_metrics.py
+++ b/src/history_book/api/routes/kg_metrics.py
@@ -84,14 +84,10 @@ async def get_node_pair_metric(
     """Get node-pair metric values relative to a focus entity (always 200).
 
     Supported metrics: cosine_similarity, jaccard_similarity, adamic_adar,
-    common_neighbor_count, shortest_path_length.
-    resistance_distance returns 501.
+    common_neighbor_count, shortest_path_length, resistance_distance.
+    resistance_distance uses Laplacian pseudoinverse (O(n³) — may be slow on large graphs).
+    Nodes in different components than the focus node get value -1.
     """
-    if metric == "resistance_distance":
-        raise HTTPException(
-            status_code=501,
-            detail="Resistance distance is not implemented (computationally infeasible on large graphs)",
-        )
     try:
         return service.get_node_pair_metric(graph_name, focus_entity_id, metric, {})
     except NotImplementedError as e:

--- a/src/history_book/database/repositories/kg_repository.py
+++ b/src/history_book/database/repositories/kg_repository.py
@@ -111,6 +111,19 @@ class KGEntityRepository(WeaviateRepository["KGEntity"]):
             **kwargs,
         )
 
+    def get_vectors(self, entity_ids: list[str]) -> dict[str, list[float]]:
+        """Fetch raw embedding vectors for a list of entity UUIDs.
+
+        Used for cosine similarity metric computation. Returns a dict mapping
+        entity_id → vector. IDs with no vector are omitted.
+        """
+        result: dict[str, list[float]] = {}
+        for entity_id in entity_ids:
+            vec = self.get_vector(entity_id)
+            if vec is not None:
+                result[entity_id] = vec
+        return result
+
     def delete_by_graph(self, graph_name: str) -> int:
         """Delete all entities for a graph. Returns count deleted."""
         entities = self.find_by_graph(graph_name)

--- a/src/history_book/services/kg_metrics_service.py
+++ b/src/history_book/services/kg_metrics_service.py
@@ -22,6 +22,12 @@ logger = logging.getLogger(__name__)
 # Maximum size for expensive O(V*E) graph metrics (avg path length, diameter)
 _MAX_COMPONENT_FOR_PATH_METRICS = 500
 
+# Percentile bounds used for node-pair metric color scale normalization.
+# Clipping at these percentiles prevents a single distant outlier node from
+# collapsing all other nodes into a narrow band of the color scale.
+_NORM_PERCENTILE_LOW = 2
+_NORM_PERCENTILE_HIGH = 98
+
 
 def _to_simple_graph(G: nx.DiGraph) -> nx.Graph:
     """Convert a MultiDiGraph to a simple undirected Graph.
@@ -410,13 +416,21 @@ class KGMetricsService:
         else:
             values[focus_id] = max(values.values()) if values else 0.0
 
-        v_list = list(values.values())
+        # Exclude sentinel -1 values (unreachable nodes) from normalization bounds.
+        # Use percentile clipping so a single outlier doesn't collapse the color scale.
+        finite_vals = [v for v in values.values() if v >= 0]
+        if finite_vals:
+            norm_min = float(np.percentile(finite_vals, _NORM_PERCENTILE_LOW))
+            norm_max = float(np.percentile(finite_vals, _NORM_PERCENTILE_HIGH))
+        else:
+            norm_min, norm_max = 0.0, 0.0
+
         return NodePairMetricResponse(
             graph_name=graph_name,
             focus_entity_id=focus_id,
             metric=metric,
             params=params,
             values=values,
-            norm_min=min(v_list) if v_list else 0.0,
-            norm_max=max(v_list) if v_list else 0.0,
+            norm_min=norm_min,
+            norm_max=norm_max,
         )

--- a/src/history_book/services/kg_metrics_service.py
+++ b/src/history_book/services/kg_metrics_service.py
@@ -121,7 +121,9 @@ class KGMetricsService:
         try:
             G = self._kg.get_nx_graph(graph_name)
             if G.number_of_nodes() == 0:
-                logger.warning("Graph %s has no nodes; storing zero metrics", graph_name)
+                logger.warning(
+                    "Graph %s has no nodes; storing zero metrics", graph_name
+                )
                 self._cache[key] = GraphMetricsResponse(
                     graph_name=graph_name,
                     density=0.0,

--- a/src/history_book/services/kg_metrics_service.py
+++ b/src/history_book/services/kg_metrics_service.py
@@ -120,6 +120,21 @@ class KGMetricsService:
     def _compute_graph_metrics(self, graph_name: str, key: tuple) -> None:
         try:
             G = self._kg.get_nx_graph(graph_name)
+            if G.number_of_nodes() == 0:
+                logger.warning("Graph %s has no nodes; storing zero metrics", graph_name)
+                self._cache[key] = GraphMetricsResponse(
+                    graph_name=graph_name,
+                    density=0.0,
+                    giant_component_ratio=0.0,
+                    num_connected_components=0,
+                    avg_shortest_path_length=None,
+                    diameter=None,
+                    global_clustering_coefficient=0.0,
+                    num_communities=0,
+                    articulation_point_count=0,
+                    status="ready",
+                )
+                return
             U = _to_simple_graph(G)
 
             density = nx.density(G)

--- a/src/history_book/services/kg_metrics_service.py
+++ b/src/history_book/services/kg_metrics_service.py
@@ -1,0 +1,383 @@
+"""Service for computing and caching network metrics on knowledge graphs."""
+
+import asyncio
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import networkx as nx
+import numpy as np
+from sklearn.cluster import SpectralClustering
+
+from history_book.api.models.kg_models import (
+    CommunityMetricResponse,
+    GraphMetricsResponse,
+    NodeMetricResponse,
+    NodePairMetricResponse,
+)
+from history_book.services.kg_service import KGService
+
+logger = logging.getLogger(__name__)
+
+# Maximum size for expensive O(V*E) graph metrics (avg path length, diameter)
+_MAX_COMPONENT_FOR_PATH_METRICS = 500
+
+
+def _cosine_sim(a: list[float], b: list[float]) -> float:
+    """Compute cosine similarity between two vectors."""
+    va = np.array(a, dtype=float)
+    vb = np.array(b, dtype=float)
+    norm_a = np.linalg.norm(va)
+    norm_b = np.linalg.norm(vb)
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return float(np.dot(va, vb) / (norm_a * norm_b))
+
+
+def _normalize(values: dict[str, float]) -> tuple[float, float]:
+    """Return (min, max) across all values."""
+    if not values:
+        return 0.0, 0.0
+    v = list(values.values())
+    return min(v), max(v)
+
+
+def _community_list_to_dict(communities: list[frozenset]) -> dict[str, int]:
+    """Convert list-of-frozensets to {node_id: community_id} dict."""
+    result: dict[str, int] = {}
+    for cid, members in enumerate(communities):
+        for node in members:
+            result[node] = cid
+    return result
+
+
+class KGMetricsService:
+    """Computes and caches network metrics for knowledge graphs.
+
+    All slow metrics (betweenness centrality, community detection, etc.) are
+    computed in a background thread pool. Callers receive a 202 placeholder
+    immediately and should poll until the cache entry is ready.
+
+    Cache key: (graph_name, metric_name, *sorted_param_items)
+    """
+
+    def __init__(self, kg_service: KGService):
+        self._kg = kg_service
+        self._cache: dict[tuple, Any] = {}
+        self._computing: set[tuple] = set()
+        self._executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="kg-metrics")
+
+    # ------------------------------------------------------------------
+    # Graph-level metrics
+    # ------------------------------------------------------------------
+
+    def trigger_graph_metrics(self, graph_name: str) -> None:
+        """Fire-and-forget trigger called as a FastAPI BackgroundTask.
+
+        Starts background computation if not already cached or computing.
+        """
+        key = (graph_name, "_graph_metrics")
+        if key in self._cache or key in self._computing:
+            return
+        self._computing.add(key)
+        self._executor.submit(self._compute_graph_metrics, graph_name, key)
+
+    async def get_graph_metrics(
+        self, graph_name: str
+    ) -> tuple[GraphMetricsResponse, int]:
+        """Return (response, http_status). Status 202 while still computing."""
+        key = (graph_name, "_graph_metrics")
+        if key in self._cache:
+            return self._cache[key], 200
+        # Start computation if not already running
+        if key not in self._computing:
+            self._computing.add(key)
+            loop = asyncio.get_event_loop()
+            loop.run_in_executor(
+                self._executor, self._compute_graph_metrics, graph_name, key
+            )
+        return self._computing_graph_placeholder(graph_name), 202
+
+    def _compute_graph_metrics(self, graph_name: str, key: tuple) -> None:
+        try:
+            G = self._kg.get_nx_graph(graph_name)
+            U = G.to_undirected()
+
+            density = nx.density(G)
+            n = len(G.nodes)
+
+            weak_components = list(nx.weakly_connected_components(G))
+            max_comp = max(weak_components, key=len) if weak_components else set()
+            giant_ratio = len(max_comp) / max(n, 1)
+            num_components = len(weak_components)
+
+            if len(max_comp) <= _MAX_COMPONENT_FOR_PATH_METRICS and len(max_comp) > 1:
+                sub_u = U.subgraph(max_comp)
+                if nx.is_connected(sub_u):
+                    avg_path: float | None = nx.average_shortest_path_length(sub_u)
+                    diameter: int | None = nx.diameter(sub_u)
+                else:
+                    avg_path = None
+                    diameter = None
+            else:
+                avg_path = None
+                diameter = None
+
+            global_cc = nx.average_clustering(U)
+            communities = list(nx.community.louvain_communities(U, seed=42))
+            artic_pts = list(nx.articulation_points(U))
+
+            result = GraphMetricsResponse(
+                graph_name=graph_name,
+                density=density,
+                giant_component_ratio=giant_ratio,
+                num_connected_components=num_components,
+                avg_shortest_path_length=avg_path,
+                diameter=diameter,
+                global_clustering_coefficient=global_cc,
+                num_communities=len(communities),
+                articulation_point_count=len(artic_pts),
+                status="ready",
+            )
+            self._cache[key] = result
+        except Exception:
+            logger.exception("Failed to compute graph metrics for %s", graph_name)
+        finally:
+            self._computing.discard(key)
+
+    @staticmethod
+    def _computing_graph_placeholder(graph_name: str) -> GraphMetricsResponse:
+        return GraphMetricsResponse(
+            graph_name=graph_name,
+            density=0.0,
+            giant_component_ratio=0.0,
+            num_connected_components=0,
+            avg_shortest_path_length=None,
+            diameter=None,
+            global_clustering_coefficient=0.0,
+            num_communities=0,
+            articulation_point_count=0,
+            status="computing",
+        )
+
+    # ------------------------------------------------------------------
+    # Node-level metrics
+    # ------------------------------------------------------------------
+
+    async def get_node_metric(
+        self, graph_name: str, metric: str, params: dict[str, float]
+    ) -> tuple[NodeMetricResponse | CommunityMetricResponse, int]:
+        """Return (response, http_status). Status 202 while still computing."""
+        key = (graph_name, metric, *sorted(params.items()))
+        if key in self._cache:
+            return self._cache[key], 200
+        if key not in self._computing:
+            self._computing.add(key)
+            loop = asyncio.get_event_loop()
+            loop.run_in_executor(
+                self._executor, self._compute_node_metric, graph_name, metric, params, key
+            )
+        return self._computing_node_placeholder(graph_name, metric, params), 202
+
+    def _compute_node_metric(
+        self, graph_name: str, metric: str, params: dict[str, float], key: tuple
+    ) -> None:
+        try:
+            G = self._kg.get_nx_graph(graph_name)
+            U = G.to_undirected()
+            result = self._dispatch_node_metric(G, U, graph_name, metric, params)
+            self._cache[key] = result
+        except Exception:
+            logger.exception(
+                "Failed to compute node metric %s for %s", metric, graph_name
+            )
+        finally:
+            self._computing.discard(key)
+
+    def _dispatch_node_metric(
+        self,
+        G: nx.DiGraph,
+        U: nx.Graph,
+        graph_name: str,
+        metric: str,
+        params: dict[str, float],
+    ) -> NodeMetricResponse | CommunityMetricResponse:
+        # --- Community metrics (return CommunityMetricResponse) ---
+        if metric == "community_louvain":
+            communities = list(nx.community.louvain_communities(U, seed=42))
+            values = _community_list_to_dict(communities)
+            return CommunityMetricResponse(
+                graph_name=graph_name,
+                metric=metric,
+                params=params,
+                values=values,
+                num_communities=len(communities),
+                status="ready",
+            )
+
+        if metric == "community_girvan_newman":
+            comp = nx.community.girvan_newman(U)
+            communities = list(next(comp))
+            values = _community_list_to_dict(communities)
+            return CommunityMetricResponse(
+                graph_name=graph_name,
+                metric=metric,
+                params=params,
+                values=values,
+                num_communities=len(communities),
+                status="ready",
+            )
+
+        if metric == "community_label_propagation":
+            communities = list(nx.community.label_propagation_communities(U))
+            values = _community_list_to_dict(communities)
+            return CommunityMetricResponse(
+                graph_name=graph_name,
+                metric=metric,
+                params=params,
+                values=values,
+                num_communities=len(communities),
+                status="ready",
+            )
+
+        if metric == "community_spectral":
+            k = int(params.get("k", 5))
+            node_list = list(U.nodes)
+            adj = nx.to_numpy_array(U, nodelist=node_list)
+            sc = SpectralClustering(
+                n_clusters=k, affinity="precomputed", random_state=42, n_init=10
+            )
+            labels = sc.fit_predict(adj)
+            values = {node_list[i]: int(labels[i]) for i in range(len(node_list))}
+            return CommunityMetricResponse(
+                graph_name=graph_name,
+                metric=metric,
+                params=params,
+                values=values,
+                num_communities=k,
+                status="ready",
+            )
+
+        # --- Continuous node metrics (return NodeMetricResponse) ---
+        if metric == "degree_centrality":
+            raw = nx.degree_centrality(G)
+        elif metric == "betweenness_centrality":
+            raw = nx.betweenness_centrality(G)
+        elif metric == "pagerank":
+            damping = params.get("damping", 0.85)
+            raw = nx.pagerank(G, alpha=damping)
+        elif metric == "closeness_centrality":
+            raw = nx.closeness_centrality(G)
+        elif metric == "kcore_number":
+            raw = {n: float(v) for n, v in nx.core_number(U).items()}
+        elif metric == "local_clustering_coefficient":
+            raw = nx.clustering(U)
+        else:
+            msg = f"Unknown node metric: {metric}"
+            raise ValueError(msg)
+
+        values = {k: float(v) for k, v in raw.items()}
+        norm_min, norm_max = _normalize(values)
+        return NodeMetricResponse(
+            graph_name=graph_name,
+            metric=metric,
+            params=params,
+            values=values,
+            norm_min=norm_min,
+            norm_max=norm_max,
+            status="ready",
+        )
+
+    @staticmethod
+    def _computing_node_placeholder(
+        graph_name: str, metric: str, params: dict[str, float]
+    ) -> NodeMetricResponse:
+        return NodeMetricResponse(
+            graph_name=graph_name,
+            metric=metric,
+            params=params,
+            values={},
+            norm_min=0.0,
+            norm_max=0.0,
+            status="computing",
+        )
+
+    # ------------------------------------------------------------------
+    # Node-pair metrics (always synchronous)
+    # ------------------------------------------------------------------
+
+    def get_node_pair_metric(
+        self, graph_name: str, focus_id: str, metric: str, params: dict[str, float]
+    ) -> NodePairMetricResponse:
+        """Compute node-pair metric relative to focus_id. Always returns immediately."""
+        G = self._kg.get_nx_graph(graph_name)
+        U = G.to_undirected()
+
+        if focus_id not in G:
+            return NodePairMetricResponse(
+                graph_name=graph_name,
+                focus_entity_id=focus_id,
+                metric=metric,
+                params=params,
+                values={},
+                norm_min=0.0,
+                norm_max=0.0,
+            )
+
+        node_ids = list(G.nodes)
+        other_ids = [n for n in node_ids if n != focus_id]
+        pairs = [(focus_id, n) for n in other_ids]
+
+        values: dict[str, float] = {}
+
+        if metric == "jaccard_similarity":
+            for _u, v, s in nx.jaccard_coefficient(U, pairs):
+                values[v] = s
+
+        elif metric == "adamic_adar":
+            for _u, v, s in nx.adamic_adar_index(U, pairs):
+                values[v] = s
+
+        elif metric == "common_neighbor_count":
+            focus_neighbors = set(U.neighbors(focus_id))
+            for n in other_ids:
+                values[n] = float(len(focus_neighbors & set(U.neighbors(n))))
+
+        elif metric == "shortest_path_length":
+            lengths = dict(
+                nx.single_source_shortest_path_length(U, focus_id)
+            )
+            for n in other_ids:
+                values[n] = float(lengths.get(n, -1))
+
+        elif metric == "cosine_similarity":
+            vectors = self._kg.get_entity_vectors(graph_name)
+            focus_vec = vectors.get(focus_id)
+            if focus_vec is not None:
+                for n in other_ids:
+                    if n in vectors:
+                        values[n] = _cosine_sim(focus_vec, vectors[n])
+
+        elif metric == "resistance_distance":
+            msg = "Resistance distance is not implemented"
+            raise NotImplementedError(msg)
+
+        else:
+            msg = f"Unknown node-pair metric: {metric}"
+            raise ValueError(msg)
+
+        # Include focus node itself with the maximum value (self-similarity)
+        max_val = max(values.values()) if values else 0.0
+        values[focus_id] = max_val
+
+        v_list = list(values.values())
+        return NodePairMetricResponse(
+            graph_name=graph_name,
+            focus_entity_id=focus_id,
+            metric=metric,
+            params=params,
+            values=values,
+            norm_min=min(v_list) if v_list else 0.0,
+            norm_max=max(v_list) if v_list else 0.0,
+        )
+

--- a/src/history_book/services/kg_metrics_service.py
+++ b/src/history_book/services/kg_metrics_service.py
@@ -23,6 +23,18 @@ logger = logging.getLogger(__name__)
 _MAX_COMPONENT_FOR_PATH_METRICS = 500
 
 
+def _to_simple_graph(G: nx.DiGraph) -> nx.Graph:
+    """Convert a MultiDiGraph to a simple undirected Graph.
+
+    Collapses parallel edges and removes self-loops, both of which cause
+    NetworkXNotImplemented errors in algorithms like core_number, clustering,
+    and articulation_points.
+    """
+    U = nx.Graph(G)
+    U.remove_edges_from(nx.selfloop_edges(U))
+    return U
+
+
 def _cosine_sim(a: list[float], b: list[float]) -> float:
     """Compute cosine similarity between two vectors."""
     va = np.array(a, dtype=float)
@@ -103,8 +115,7 @@ class KGMetricsService:
     def _compute_graph_metrics(self, graph_name: str, key: tuple) -> None:
         try:
             G = self._kg.get_nx_graph(graph_name)
-            # Collapse MultiDiGraph → simple Graph for algorithms that don't support multigraphs
-            U = nx.Graph(G)
+            U = _to_simple_graph(G)
 
             density = nx.density(G)
             n = len(G.nodes)
@@ -192,7 +203,7 @@ class KGMetricsService:
     ) -> None:
         try:
             G = self._kg.get_nx_graph(graph_name)
-            U = nx.Graph(G)  # collapse MultiDiGraph → simple Graph
+            U = _to_simple_graph(G)
             result = self._dispatch_node_metric(G, U, graph_name, metric, params)
             self._cache[key] = result
         except Exception:

--- a/src/history_book/services/kg_metrics_service.py
+++ b/src/history_book/services/kg_metrics_service.py
@@ -103,7 +103,6 @@ class KGMetricsService:
         key = (graph_name, "_graph_metrics")
         if key in self._cache:
             return self._cache[key], 200
-        # Start computation if not already running
         if key not in self._computing:
             self._computing.add(key)
             loop = asyncio.get_event_loop()
@@ -376,16 +375,40 @@ class KGMetricsService:
                         values[n] = _cosine_sim(focus_vec, vectors[n])
 
         elif metric == "resistance_distance":
-            msg = "Resistance distance is not implemented"
-            raise NotImplementedError(msg)
+            # Effective resistance via Laplacian pseudoinverse.
+            # R(i,j) = L⁺[i,i] + L⁺[j,j] - 2·L⁺[i,j]  (O(n³) — slow on large graphs)
+            # Nodes in different components get -1 (unreachable).
+            node_list = list(U.nodes)
+            if focus_id not in U:
+                pass  # values stays empty
+            else:
+                focus_idx = node_list.index(focus_id)
+                focus_component = nx.node_connected_component(U, focus_id)
+                L = nx.laplacian_matrix(U, nodelist=node_list).toarray().astype(float)
+                L_pinv = np.linalg.pinv(L)
+                for i, n in enumerate(node_list):
+                    if n == focus_id:
+                        continue
+                    if n not in focus_component:
+                        values[n] = -1.0
+                    else:
+                        values[n] = float(
+                            L_pinv[focus_idx, focus_idx]
+                            + L_pinv[i, i]
+                            - 2 * L_pinv[focus_idx, i]
+                        )
 
         else:
             msg = f"Unknown node-pair metric: {metric}"
             raise ValueError(msg)
 
-        # Include focus node itself with the maximum value (self-similarity)
-        max_val = max(values.values()) if values else 0.0
-        values[focus_id] = max_val
+        # For distance metrics, self-distance is 0 (not max).
+        # For similarity metrics, self-similarity is the maximum value.
+        _distance_metrics = {"resistance_distance", "shortest_path_length"}
+        if metric in _distance_metrics:
+            values[focus_id] = 0.0
+        else:
+            values[focus_id] = max(values.values()) if values else 0.0
 
         v_list = list(values.values())
         return NodePairMetricResponse(

--- a/src/history_book/services/kg_metrics_service.py
+++ b/src/history_book/services/kg_metrics_service.py
@@ -65,7 +65,9 @@ class KGMetricsService:
         self._kg = kg_service
         self._cache: dict[tuple, Any] = {}
         self._computing: set[tuple] = set()
-        self._executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="kg-metrics")
+        self._executor = ThreadPoolExecutor(
+            max_workers=2, thread_name_prefix="kg-metrics"
+        )
 
     # ------------------------------------------------------------------
     # Graph-level metrics
@@ -101,7 +103,8 @@ class KGMetricsService:
     def _compute_graph_metrics(self, graph_name: str, key: tuple) -> None:
         try:
             G = self._kg.get_nx_graph(graph_name)
-            U = G.to_undirected()
+            # Collapse MultiDiGraph → simple Graph for algorithms that don't support multigraphs
+            U = nx.Graph(G)
 
             density = nx.density(G)
             n = len(G.nodes)
@@ -175,7 +178,12 @@ class KGMetricsService:
             self._computing.add(key)
             loop = asyncio.get_event_loop()
             loop.run_in_executor(
-                self._executor, self._compute_node_metric, graph_name, metric, params, key
+                self._executor,
+                self._compute_node_metric,
+                graph_name,
+                metric,
+                params,
+                key,
             )
         return self._computing_node_placeholder(graph_name, metric, params), 202
 
@@ -184,7 +192,7 @@ class KGMetricsService:
     ) -> None:
         try:
             G = self._kg.get_nx_graph(graph_name)
-            U = G.to_undirected()
+            U = nx.Graph(G)  # collapse MultiDiGraph → simple Graph
             result = self._dispatch_node_metric(G, U, graph_name, metric, params)
             self._cache[key] = result
         except Exception:
@@ -311,7 +319,7 @@ class KGMetricsService:
     ) -> NodePairMetricResponse:
         """Compute node-pair metric relative to focus_id. Always returns immediately."""
         G = self._kg.get_nx_graph(graph_name)
-        U = G.to_undirected()
+        U = nx.Graph(G)  # collapse MultiDiGraph → simple Graph
 
         if focus_id not in G:
             return NodePairMetricResponse(
@@ -344,9 +352,7 @@ class KGMetricsService:
                 values[n] = float(len(focus_neighbors & set(U.neighbors(n))))
 
         elif metric == "shortest_path_length":
-            lengths = dict(
-                nx.single_source_shortest_path_length(U, focus_id)
-            )
+            lengths = dict(nx.single_source_shortest_path_length(U, focus_id))
             for n in other_ids:
                 values[n] = float(lengths.get(n, -1))
 
@@ -380,4 +386,3 @@ class KGMetricsService:
             norm_min=min(v_list) if v_list else 0.0,
             norm_max=max(v_list) if v_list else 0.0,
         )
-

--- a/src/history_book/services/kg_service.py
+++ b/src/history_book/services/kg_service.py
@@ -19,6 +19,10 @@ from history_book.database.repositories import BookRepositoryManager
 
 logger = logging.getLogger(__name__)
 
+# Weakly-connected components smaller than this are excluded from the cached NX graph,
+# the serialized GraphResponse, and all metric computations.
+_MIN_COMPONENT_SIZE = 6
+
 
 class KGService:
     """Service for reading knowledge graph data."""
@@ -35,14 +39,24 @@ class KGService:
         return self.repo_manager.kg_graphs.list_all()
 
     def get_graph(self, graph_name: str) -> GraphResponse:
-        """Return all nodes and links for a named graph."""
+        """Return all nodes and links for a named graph.
+
+        Components smaller than _MIN_COMPONENT_SIZE are excluded from both
+        the response and subsequent metric computations (via the NX cache).
+        """
         entities = self.repo_manager.kg_entities.find_by_graph(graph_name)
         relationships = self.repo_manager.kg_relationships.find_by_graph(graph_name)
-        # Build and cache NX graph while we have the data, avoiding a second
-        # DB round-trip when get_subgraph is called subsequently.
         if graph_name not in self._nx_cache:
-            self._nx_cache[graph_name] = self._build_nx_graph(entities, relationships)
-        return self._build_graph_response(entities, relationships, graph_name)
+            raw = self._build_nx_graph(entities, relationships)
+            self._nx_cache[graph_name] = self._filter_small_components(raw)
+        G = self._nx_cache[graph_name]
+        keep_ids = set(G.nodes)
+        filtered_entities = [e for e in entities if e.id in keep_ids]
+        filtered_relationships = [
+            r for r in relationships
+            if r.source_entity_id in keep_ids and r.target_entity_id in keep_ids
+        ]
+        return self._build_graph_response(filtered_entities, filtered_relationships, graph_name)
 
     def get_subgraph(self, entity_id: str, hops: int, graph_name: str) -> GraphResponse:
         """Return an N-hop subgraph centered on entity_id within graph_name."""
@@ -141,10 +155,7 @@ class KGService:
         return SearchResponse(results=search_results, query=query)
 
     def get_entity_vectors(self, graph_name: str) -> dict[str, list[float]]:
-        """Return embedding vectors for all entities in a graph.
-
-        Used by KGMetricsService for cosine similarity computation.
-        """
+        """Return embedding vectors for all entities in a (filtered) graph."""
         G = self.get_nx_graph(graph_name)
         entity_ids = list(G.nodes)
         return self.repo_manager.kg_entities.get_vectors(entity_ids)
@@ -154,12 +165,24 @@ class KGService:
     # ------------------------------------------------------------------
 
     def get_nx_graph(self, graph_name: str) -> nx.DiGraph:
-        """Return cached NX graph, building from DB if not yet cached."""
+        """Return cached NX graph, building and filtering from DB if not yet cached."""
         if graph_name not in self._nx_cache:
             entities = self.repo_manager.kg_entities.find_by_graph(graph_name)
             relationships = self.repo_manager.kg_relationships.find_by_graph(graph_name)
-            self._nx_cache[graph_name] = self._build_nx_graph(entities, relationships)
+            raw = self._build_nx_graph(entities, relationships)
+            self._nx_cache[graph_name] = self._filter_small_components(raw)
         return self._nx_cache[graph_name]
+
+    def _filter_small_components(self, G: nx.DiGraph) -> nx.DiGraph:
+        """Return a subgraph of G with components smaller than _MIN_COMPONENT_SIZE removed."""
+        U = nx.Graph(G)
+        keep_ids: set[str] = {
+            n
+            for component in nx.connected_components(U)
+            if len(component) >= _MIN_COMPONENT_SIZE
+            for n in component
+        }
+        return G.subgraph(keep_ids).copy()
 
     def _build_nx_graph(
         self, entities: list[KGEntity], relationships: list[KGRelationship]

--- a/src/history_book/services/kg_service.py
+++ b/src/history_book/services/kg_service.py
@@ -53,10 +53,13 @@ class KGService:
         keep_ids = set(G.nodes)
         filtered_entities = [e for e in entities if e.id in keep_ids]
         filtered_relationships = [
-            r for r in relationships
+            r
+            for r in relationships
             if r.source_entity_id in keep_ids and r.target_entity_id in keep_ids
         ]
-        return self._build_graph_response(filtered_entities, filtered_relationships, graph_name)
+        return self._build_graph_response(
+            filtered_entities, filtered_relationships, graph_name
+        )
 
     def get_subgraph(self, entity_id: str, hops: int, graph_name: str) -> GraphResponse:
         """Return an N-hop subgraph centered on entity_id within graph_name."""

--- a/src/history_book/services/kg_service.py
+++ b/src/history_book/services/kg_service.py
@@ -46,7 +46,7 @@ class KGService:
 
     def get_subgraph(self, entity_id: str, hops: int, graph_name: str) -> GraphResponse:
         """Return an N-hop subgraph centered on entity_id within graph_name."""
-        G = self._get_nx_graph(graph_name)
+        G = self.get_nx_graph(graph_name)
         if entity_id not in G:
             return GraphResponse(
                 nodes=[], links=[], graph_name=graph_name, node_count=0, edge_count=0
@@ -140,11 +140,20 @@ class KGService:
 
         return SearchResponse(results=search_results, query=query)
 
+    def get_entity_vectors(self, graph_name: str) -> dict[str, list[float]]:
+        """Return embedding vectors for all entities in a graph.
+
+        Used by KGMetricsService for cosine similarity computation.
+        """
+        G = self.get_nx_graph(graph_name)
+        entity_ids = list(G.nodes)
+        return self.repo_manager.kg_entities.get_vectors(entity_ids)
+
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _get_nx_graph(self, graph_name: str) -> nx.DiGraph:
+    def get_nx_graph(self, graph_name: str) -> nx.DiGraph:
         """Return cached NX graph, building from DB if not yet cached."""
         if graph_name not in self._nx_cache:
             entities = self.repo_manager.kg_entities.find_by_graph(graph_name)


### PR DESCRIPTION
## Add network metrics to KG Explorer

Adds a full suite of graph and node-level network metrics to the KG Explorer, computed on the backend and visualized in the frontend.

**Backend**
- New `KGMetricsService` computing three categories of metrics via NetworkX:
  - *Graph-level*: density, giant component ratio, clustering coefficient, community count, articulation points, avg path length, diameter
  - *Node-level*: degree/betweenness/closeness centrality, PageRank, k-core number, local clustering coefficient, community detection (Louvain, Girvan-Newman, label propagation, spectral)
  - *Node-pair*: cosine similarity, Jaccard, Adamic-Adar, common neighbors, shortest path length, resistance distance (Laplacian pseudoinverse)
- Slow metrics computed in a background thread pool; API returns 202 while computing so the frontend can poll
- Small connected components (< 6 nodes) filtered from the NX graph at cache time, so orphan nodes don't distort community detection or centrality scores
- Node-pair metric norms clipped at 2nd/98th percentile to prevent outlier nodes from collapsing the color scale

**Frontend**
- Size and color metric selectors in the top bar; node size and color driven by selected metrics
- Color scale normalized to currently *displayed* nodes (respects occurrence filter, leaf trim, N-hop subgraph)
- Distance metrics (resistance distance, shortest path) use an inverted viridis scale so proximity = bright
- Legend overlay on the graph canvas: entity-type swatches or viridis gradient bar with min/max labels
- Metric enums replace string literals; `METRIC_LABELS` and `METRIC_TOOLTIPS` as single sources of truth for display names and dropdown descriptions
- Tooltips on all metric dropdown items and key toolbar controls
